### PR TITLE
エラーハンドリングの実装

### DIFF
--- a/apis/v1/errors.go
+++ b/apis/v1/errors.go
@@ -1,0 +1,92 @@
+// Copyright 2021-2022 The phy-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// errorResponser APIレスポンスが返すエラー型が実装すべきインターフェース
+//
+// Note: 本来は各エラー型(ErrorNNN)でerrorインターフェースを実装させたかったが、
+//       各エラー型にはswagger.yamlでErrorというフィールドが定義されているため実装できない。
+//       このため別途errorを返すためのインターフェースとしてerrorResponserを用いている。
+type errorResponser interface {
+	ActualError() error
+}
+
+var (
+	_ errorResponser = (*Error400)(nil)
+	_ errorResponser = (*Error401)(nil)
+	_ errorResponser = (*Error403)(nil)
+	_ errorResponser = (*Error404)(nil)
+	_ errorResponser = (*Error409)(nil)
+	_ errorResponser = (*ErrorDefault)(nil)
+)
+
+var commonErrorFormat = "status: %d, message: %s, trace: %s, inner_error: %s"
+
+func (e Error400) ActualError() error {
+	return fmt.Errorf(commonErrorFormat, http.StatusBadRequest, e.Error.Message, e.Error.TraceId, e.Error.Errors)
+}
+
+func (e Error401) ActualError() error {
+	return fmt.Errorf(commonErrorFormat, http.StatusUnauthorized, e.Error.Message, e.Error.TraceId, e.Error.Errors)
+}
+
+func (e Error403) ActualError() error {
+	return fmt.Errorf(commonErrorFormat, http.StatusForbidden, e.Error.Message, e.Error.TraceId, e.Error.Errors)
+}
+
+func (e Error404) ActualError() error {
+	return fmt.Errorf(commonErrorFormat, http.StatusNotFound, e.Error.Message, e.Error.TraceId, e.Error.Errors)
+}
+
+func (e Error409) ActualError() error {
+	return fmt.Errorf(commonErrorFormat, http.StatusConflict, e.Error.Message, e.Error.TraceId, e.Error.Errors)
+}
+
+func (e ErrorDefault) ActualError() error {
+	status := e.Error.Code
+	if status == 0 {
+		// この段階までに既知のステータスコード判定はされている。ここで不明な場合は500にしておく
+		status = http.StatusInternalServerError
+	}
+	return fmt.Errorf(commonErrorFormat, status, e.Error.Message, e.Error.TraceId, e.Error.Errors)
+}
+
+func (e Error) String() string {
+	return fmt.Sprintf("domain: %s, location: %s, location_type: %s, message: %s, reason: %s",
+		e.Domain,
+		e.Location,
+		e.LocationType,
+		e.Message,
+		e.Reason,
+	)
+}
+
+func (e Errors) String() string {
+	if len(e) == 0 {
+		return "(empty)"
+	}
+	var errorStrings []string
+	for _, err := range e {
+		errorStrings = append(errorStrings, fmt.Sprintf("{%s}", err.String()))
+	}
+
+	return strings.Join(errorStrings, ", ")
+}

--- a/apis/v1/example_test.go
+++ b/apis/v1/example_test.go
@@ -42,12 +42,17 @@ func Example() {
 		panic(err)
 	}
 
-	sites, err := client.ListClustersWithResponse(context.Background())
+	resp, err := client.ListClustersWithResponse(context.Background())
 	if err != nil {
 		panic(err)
 	}
 
-	site := (*sites.JSON200.Data)[0]
+	sites, err := resp.Result()
+	if err != nil {
+		panic(err)
+	}
+
+	site := (*sites.Data)[0]
 	fmt.Println(*site.DisplayName)
 	// output:
 	// 石狩第1サイト

--- a/apis/v1/functions.go
+++ b/apis/v1/functions.go
@@ -1,0 +1,56 @@
+// Copyright 2021-2022 The phy-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+)
+
+func eCoalesce(errs ...interface{}) error {
+	for _, e := range errs {
+		if !(e == nil || reflect.ValueOf(e).IsNil()) {
+			return toError(e)
+		}
+	}
+	return nil
+}
+
+// toError errorまたはerrorResponserの実装からerrorを返す
+// 上記以外またはnilを渡した場合はpanicするため呼び出し側でチェックする必要がある
+func toError(v interface{}) error {
+	switch err := v.(type) {
+	case error:
+		return err
+	case errorResponser:
+		return err.ActualError()
+	default:
+		msg := fmt.Sprintf("invalid arg: %#+v", v)
+		panic(msg)
+	}
+}
+
+var osStatusCodes = map[int]bool{
+	http.StatusOK:        true,
+	http.StatusCreated:   true,
+	http.StatusAccepted:  true,
+	http.StatusNoContent: true,
+}
+
+func isOKStatus(httpStatusCode int) bool {
+	_, ok := osStatusCodes[httpStatusCode]
+	return ok
+}

--- a/apis/v1/spec/codegen/templates/client-with-responses.tmpl
+++ b/apis/v1/spec/codegen/templates/client-with-responses.tmpl
@@ -64,20 +64,19 @@ return r.HTTPResponse.StatusCode
 return 0
 }
 
-// TODO 後で検討
-// {{ $json200Type := "" }}{{ range getResponseTypeDefinitions . }}{{ if eq .TypeName "JSON200" }}{{ $json200Type = .Schema.TypeDecl }}{{ end }}{{ end -}}
-// // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r {{$opid | ucFirst}}Response) Result() ({{if $json200Type}}*{{ $json200Type}},{{end}}error) {
-//     return {{if $json200Type}}r.JSON200, {{end}}eCoalesce({{range getResponseTypeDefinitions .}}{{ if ne .TypeName "JSON200" }}r.{{.TypeName}},{{end}}{{end}}r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r {{$opid | ucFirst}}Response) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+{{ $json200Type := "" }}{{ range getResponseTypeDefinitions . }}{{ if eq .TypeName "JSON200" }}{{ $json200Type = .Schema.TypeDecl }}{{ end }}{{ end -}}
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r {{$opid | ucFirst}}Response) Result() ({{if $json200Type}}*{{ $json200Type}},{{end}}error) {
+    return {{if $json200Type}}r.JSON200, {{end}}eCoalesce({{range getResponseTypeDefinitions .}}{{ if ne .TypeName "JSON200" }}r.{{.TypeName}},{{end}}{{end}}r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r {{$opid | ucFirst}}Response) UndefinedError() error {
+    if !isOKStatus(r.HTTPResponse.StatusCode){
+        return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+    }
+    return nil
+}
 {{end}}
 
 

--- a/apis/v1/spec/swagger.yaml
+++ b/apis/v1/spec/swagger.yaml
@@ -1933,157 +1933,86 @@ components:
         認証に関するエラーについて詳細なエラー内容を表示する。
       type: array
       items:
-        type: object
-        properties:
-          domain:
-            allOf:
-              - $ref: '#/components/schemas/ErrorsDomain'
-            example: '{federaton,cluster}-api-objectstorage.sacloud'
-          location:
-            allOf:
-              - $ref: '#/components/schemas/ErrorsLocation'
-            example: String
-          location_type:
-            allOf:
-              - $ref: '#/components/schemas/ErrorsLocationType'
-            example: String
-          message:
-            allOf:
-              - $ref: '#/components/schemas/ErrorsMessage'
-            example: XXXX failed.
-          reason:
-            allOf:
-              - $ref: '#/components/schemas/ErrorsReason'
-            example: XXXX is wrong. Should set valid parameters.
+        $ref: "#/components/schemas/Error"
+
+    # Errorsから切り出し
+    Error:
+      type: object
+      properties:
+        domain:
+          $ref: '#/components/schemas/ErrorsDomain'
+        location:
+          $ref: '#/components/schemas/ErrorsLocation'
+        location_type:
+          $ref: '#/components/schemas/ErrorsLocationType'
+        message:
+          $ref: '#/components/schemas/ErrorsMessage'
+        reason:
+          $ref: '#/components/schemas/ErrorsReason'
+      required:
+        - domain
+        - location
+        - location_type
+        - message
+        - reason
     Error400:
       type: object
       properties:
         error:
-          description: error 400
-          type: object
-          properties:
-            code:
-              allOf:
-                - $ref: '#/components/schemas/ErrorCode'
-              example: 400
-            message:
-              allOf:
-                - $ref: '#/components/schemas/ErrorMessage'
-              example: Invalid parameters.
-            trace_id:
-              allOf:
-                - $ref: '#/components/schemas/ErrorTraceId'
-              example: 0f36837633984f3fc8871f515e8efa24
-            errors:
-              allOf:
-                - $ref: '#/components/schemas/Errors'
+          $ref: "#/components/schemas/ErrorDetail"
+      required:
+        - error
     Error401:
       type: object
       properties:
         error:
-          description: error 401
-          type: object
-          properties:
-            code:
-              allOf:
-                - $ref: '#/components/schemas/ErrorCode'
-              example: 401
-            message:
-              allOf:
-                - $ref: '#/components/schemas/ErrorMessage'
-              example: Authentication failed.
-            trace_id:
-              allOf:
-                - $ref: '#/components/schemas/ErrorTraceId'
-              example: 0f36837633984f3fc8871f515e8efa24
-            errors:
-              allOf:
-                - $ref: '#/components/schemas/Errors'
+          $ref: "#/components/schemas/ErrorDetail"
+      required:
+        - error
     Error403:
       type: object
       properties:
         error:
-          description: error 403
-          type: object
-          properties:
-            code:
-              allOf:
-                - $ref: '#/components/schemas/ErrorCode'
-              example: 403
-            message:
-              allOf:
-                - $ref: '#/components/schemas/ErrorMessage'
-              example: XXXX creation denied.
-            trace_id:
-              allOf:
-                - $ref: '#/components/schemas/ErrorTraceId'
-              example: 0f36837633984f3fc8871f515e8efa24
-            errors:
-              allOf:
-                - $ref: '#/components/schemas/Errors'
+          $ref: "#/components/schemas/ErrorDetail"
+      required:
+        - error
     Error404:
       type: object
       properties:
         error:
-          description: error 404
-          type: object
-          properties:
-            code:
-              allOf:
-                - $ref: '#/components/schemas/ErrorCode'
-              example: 404
-            message:
-              allOf:
-                - $ref: '#/components/schemas/ErrorMessage'
-              example: XXXX does not exist.
-            trace_id:
-              allOf:
-                - $ref: '#/components/schemas/ErrorTraceId'
-              example: 0f36837633984f3fc8871f515e8efa24
-            errors:
-              allOf:
-                - $ref: '#/components/schemas/Errors'
+          $ref: "#/components/schemas/ErrorDetail"
+      required:
+        - error
     Error409:
       type: object
       properties:
         error:
-          description: error 409
-          type: object
-          properties:
-            code:
-              allOf:
-                - $ref: '#/components/schemas/ErrorCode'
-              example: 409
-            message:
-              allOf:
-                - $ref: '#/components/schemas/ErrorMessage'
-              example: XXXX already created.
-            trace_id:
-              allOf:
-                - $ref: '#/components/schemas/ErrorTraceId'
-              example: 0f36837633984f3fc8871f515e8efa24
-            errors:
-              allOf:
-                - $ref: '#/components/schemas/Errors'
+          $ref: "#/components/schemas/ErrorDetail"
+      required:
+        - error
     ErrorDefault:
       type: object
       properties:
         error:
-          description: error 500
-          type: object
-          properties:
-            code:
-              allOf:
-                - $ref: '#/components/schemas/ErrorCode'
-              example: 500
-            message:
-              allOf:
-                - $ref: '#/components/schemas/ErrorMessage'
-              example: unknown error occurred.
-            trace_id:
-              allOf:
-                - $ref: '#/components/schemas/ErrorTraceId'
-              example: 0f36837633984f3fc8871f515e8efa24
-            errors:
-              allOf:
-                - $ref: '#/components/schemas/Errors'
+          $ref: "#/components/schemas/ErrorDetail"
+      required:
+        - error
+
+    # ErrorNNNから切り出し
+    ErrorDetail:
+      description: error
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode'
+        message:
+          $ref: '#/components/schemas/ErrorMessage'
+        trace_id:
+          $ref: '#/components/schemas/ErrorTraceId'
+        errors:
+          $ref: '#/components/schemas/Errors'
+      required:
+        - code
+        - message
+        - trace_id
+        - errors

--- a/apis/v1/zz_client_gen.go
+++ b/apis/v1/zz_client_gen.go
@@ -1451,19 +1451,18 @@ func (r DeleteBucketResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r DeleteBucketResponse) Result() (error) {
-//     return eCoalesce(r.JSON201,r.JSON400,r.JSON409,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r DeleteBucketResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r DeleteBucketResponse) Result() error {
+	return eCoalesce(r.JSON201, r.JSON400, r.JSON409, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r DeleteBucketResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type CreateBucketResponse struct {
 	Body         []byte
@@ -1490,19 +1489,18 @@ func (r CreateBucketResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r CreateBucketResponse) Result() (error) {
-//     return eCoalesce(r.JSON201,r.JSON400,r.JSON404,r.JSON409,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r CreateBucketResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r CreateBucketResponse) Result() error {
+	return eCoalesce(r.JSON201, r.JSON400, r.JSON404, r.JSON409, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r CreateBucketResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type ListClustersResponse struct {
 	Body         []byte
@@ -1527,19 +1525,18 @@ func (r ListClustersResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r ListClustersResponse) Result() (*HandlerListClustersRes,error) {
-//     return r.JSON200, eCoalesce(r.JSON401,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r ListClustersResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r ListClustersResponse) Result() (*HandlerListClustersRes, error) {
+	return r.JSON200, eCoalesce(r.JSON401, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r ListClustersResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type ReadClusterResponse struct {
 	Body         []byte
@@ -1565,19 +1562,18 @@ func (r ReadClusterResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r ReadClusterResponse) Result() (*HandlerGetClusterRes,error) {
-//     return r.JSON200, eCoalesce(r.JSON401,r.JSON404,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r ReadClusterResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r ReadClusterResponse) Result() (*HandlerGetClusterRes, error) {
+	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r ReadClusterResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type DeleteSiteAccountResponse struct {
 	Body         []byte
@@ -1603,19 +1599,18 @@ func (r DeleteSiteAccountResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r DeleteSiteAccountResponse) Result() (error) {
-//     return eCoalesce(r.JSON401,r.JSON409,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r DeleteSiteAccountResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r DeleteSiteAccountResponse) Result() error {
+	return eCoalesce(r.JSON401, r.JSON409, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r DeleteSiteAccountResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type ReadSiteAccountResponse struct {
 	Body         []byte
@@ -1642,19 +1637,18 @@ func (r ReadSiteAccountResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r ReadSiteAccountResponse) Result() (*Account,error) {
-//     return r.JSON200, eCoalesce(r.JSON401,r.JSON404,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r ReadSiteAccountResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r ReadSiteAccountResponse) Result() (*Account, error) {
+	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r ReadSiteAccountResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type CreateSiteAccountResponse struct {
 	Body         []byte
@@ -1682,19 +1676,18 @@ func (r CreateSiteAccountResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r CreateSiteAccountResponse) Result() (error) {
-//     return eCoalesce(r.JSON201,r.JSON401,r.JSON403,r.JSON409,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r CreateSiteAccountResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r CreateSiteAccountResponse) Result() error {
+	return eCoalesce(r.JSON201, r.JSON401, r.JSON403, r.JSON409, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r CreateSiteAccountResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type ListAccountAccessKeysResponse struct {
 	Body         []byte
@@ -1721,19 +1714,18 @@ func (r ListAccountAccessKeysResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r ListAccountAccessKeysResponse) Result() (*AccountKeys,error) {
-//     return r.JSON200, eCoalesce(r.JSON401,r.JSON404,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r ListAccountAccessKeysResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r ListAccountAccessKeysResponse) Result() (*AccountKeys, error) {
+	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r ListAccountAccessKeysResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type CreateAccountAccessKeyResponse struct {
 	Body         []byte
@@ -1761,19 +1753,18 @@ func (r CreateAccountAccessKeyResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r CreateAccountAccessKeyResponse) Result() (error) {
-//     return eCoalesce(r.JSON201,r.JSON401,r.JSON404,r.JSON409,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r CreateAccountAccessKeyResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r CreateAccountAccessKeyResponse) Result() error {
+	return eCoalesce(r.JSON201, r.JSON401, r.JSON404, r.JSON409, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r CreateAccountAccessKeyResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type DeleteAccountAccessKeyResponse struct {
 	Body         []byte
@@ -1798,19 +1789,18 @@ func (r DeleteAccountAccessKeyResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r DeleteAccountAccessKeyResponse) Result() (error) {
-//     return eCoalesce(r.JSON401,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r DeleteAccountAccessKeyResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r DeleteAccountAccessKeyResponse) Result() error {
+	return eCoalesce(r.JSON401, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r DeleteAccountAccessKeyResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type ReadAccountAccessKeyResponse struct {
 	Body         []byte
@@ -1837,19 +1827,18 @@ func (r ReadAccountAccessKeyResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r ReadAccountAccessKeyResponse) Result() (*AccountKey,error) {
-//     return r.JSON200, eCoalesce(r.JSON401,r.JSON404,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r ReadAccountAccessKeyResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r ReadAccountAccessKeyResponse) Result() (*AccountKey, error) {
+	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r ReadAccountAccessKeyResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type ListPermissionsResponse struct {
 	Body         []byte
@@ -1875,19 +1864,18 @@ func (r ListPermissionsResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r ListPermissionsResponse) Result() (*Permission,error) {
-//     return r.JSON200, eCoalesce(r.JSON401,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r ListPermissionsResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r ListPermissionsResponse) Result() (*Permission, error) {
+	return r.JSON200, eCoalesce(r.JSON401, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r ListPermissionsResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type CreatePermissionResponse struct {
 	Body         []byte
@@ -1915,19 +1903,18 @@ func (r CreatePermissionResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r CreatePermissionResponse) Result() (error) {
-//     return eCoalesce(r.JSON201,r.JSON401,r.JSON404,r.JSON409,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r CreatePermissionResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r CreatePermissionResponse) Result() error {
+	return eCoalesce(r.JSON201, r.JSON401, r.JSON404, r.JSON409, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r CreatePermissionResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type DeletePermissionResponse struct {
 	Body         []byte
@@ -1952,19 +1939,18 @@ func (r DeletePermissionResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r DeletePermissionResponse) Result() (error) {
-//     return eCoalesce(r.JSON401,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r DeletePermissionResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r DeletePermissionResponse) Result() error {
+	return eCoalesce(r.JSON401, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r DeletePermissionResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type ReadPermissionResponse struct {
 	Body         []byte
@@ -1991,19 +1977,18 @@ func (r ReadPermissionResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r ReadPermissionResponse) Result() (*Permission,error) {
-//     return r.JSON200, eCoalesce(r.JSON401,r.JSON404,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r ReadPermissionResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r ReadPermissionResponse) Result() (*Permission, error) {
+	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r ReadPermissionResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type UpdatePermissionResponse struct {
 	Body         []byte
@@ -2031,19 +2016,18 @@ func (r UpdatePermissionResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r UpdatePermissionResponse) Result() (*Permission,error) {
-//     return r.JSON200, eCoalesce(r.JSON401,r.JSON404,r.JSON409,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r UpdatePermissionResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r UpdatePermissionResponse) Result() (*Permission, error) {
+	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.JSON409, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r UpdatePermissionResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type ListPermissionAccessKeysResponse struct {
 	Body         []byte
@@ -2070,19 +2054,18 @@ func (r ListPermissionAccessKeysResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r ListPermissionAccessKeysResponse) Result() (*PermissionKey,error) {
-//     return r.JSON200, eCoalesce(r.JSON401,r.JSON404,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r ListPermissionAccessKeysResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r ListPermissionAccessKeysResponse) Result() (*PermissionKey, error) {
+	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r ListPermissionAccessKeysResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type CreatePermissionAccessKeyResponse struct {
 	Body         []byte
@@ -2110,19 +2093,18 @@ func (r CreatePermissionAccessKeyResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r CreatePermissionAccessKeyResponse) Result() (error) {
-//     return eCoalesce(r.JSON201,r.JSON401,r.JSON404,r.JSON409,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r CreatePermissionAccessKeyResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r CreatePermissionAccessKeyResponse) Result() error {
+	return eCoalesce(r.JSON201, r.JSON401, r.JSON404, r.JSON409, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r CreatePermissionAccessKeyResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type DeletePermissionAccessKeyResponse struct {
 	Body         []byte
@@ -2148,19 +2130,18 @@ func (r DeletePermissionAccessKeyResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r DeletePermissionAccessKeyResponse) Result() (error) {
-//     return eCoalesce(r.JSON401,r.JSON404,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r DeletePermissionAccessKeyResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r DeletePermissionAccessKeyResponse) Result() error {
+	return eCoalesce(r.JSON401, r.JSON404, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r DeletePermissionAccessKeyResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type ReadPermissionAccessKeyResponse struct {
 	Body         []byte
@@ -2187,19 +2168,18 @@ func (r ReadPermissionAccessKeyResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r ReadPermissionAccessKeyResponse) Result() (*PermissionKey,error) {
-//     return r.JSON200, eCoalesce(r.JSON401,r.JSON404,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r ReadPermissionAccessKeyResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r ReadPermissionAccessKeyResponse) Result() (*PermissionKey, error) {
+	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r ReadPermissionAccessKeyResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 type ReadSiteStatusResponse struct {
 	Body         []byte
@@ -2225,19 +2205,18 @@ func (r ReadSiteStatusResponse) StatusCode() int {
 	return 0
 }
 
-// TODO 後で検討
-// // // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-// func (r ReadSiteStatusResponse) Result() (*Status,error) {
-//     return r.JSON200, eCoalesce(r.JSON401,r.JSONDefault,r.UndefinedError())
-// }
-//
-// // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-// func (r ReadSiteStatusResponse) UndefinedError() error {
-//     if !isOKStatus(r.HTTPResponse.StatusCode){
-//         return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
-//     }
-//     return nil
-// }
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r ReadSiteStatusResponse) Result() (*Status, error) {
+	return r.JSON200, eCoalesce(r.JSON401, r.JSONDefault, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r ReadSiteStatusResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
 
 // DeleteBucketWithBodyWithResponse request with arbitrary body returning *DeleteBucketResponse
 func (c *ClientWithResponses) DeleteBucketWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeleteBucketResponse, error) {

--- a/apis/v1/zz_types_gen.go
+++ b/apis/v1/zz_types_gen.go
@@ -76,119 +76,59 @@ type CreatedAt time.Time
 // Display name
 type DisplayName string
 
+// Error defines model for Error.
+type Error struct {
+	// どのサービスで発生したエラーかを判別する。
+	// マイクロサービス名に加えてクラスター名を含む文字列が入ることを想定している。
+	Domain ErrorsDomain `json:"domain"`
+
+	// エラー発生箇所。
+	// どのリソースなのか（どのリソースを操作した時に発生したものなのか）、
+	// どのパラメータなのかといった情報。
+	Location ErrorsLocation `json:"location"`
+
+	// エラーの発生箇所の種類。
+	// HTTPヘッダなのかHTTPパラメータなのか、
+	// S3バケットなのかといったlocationの種別情報。
+	LocationType ErrorsLocationType `json:"location_type"`
+
+	// エラー発生時のメッセージ内容。
+	// このメッセージはエラーを発生させたアプリケーションのメッセージをそのまま含む場合がある。
+	Message ErrorsMessage `json:"message"`
+
+	// なぜそのエラーが発生したかがわかる情報。
+	// エラーメッセージの原因やエラー解決のためのヒントも含む場合がある。
+	Reason ErrorsReason `json:"reason"`
+}
+
 // Error400 defines model for Error400.
 type Error400 struct {
-	// error 400
-	Error *struct {
-		Code *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorCode)
-			ErrorCode `yaml:",inline"`
-		} `json:"code,omitempty"`
-		Errors *struct {
-			// Embedded struct due to allOf(#/components/schemas/Errors)
-			Errors `yaml:",inline"`
-		} `json:"errors,omitempty"`
-		Message *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorMessage)
-			ErrorMessage `yaml:",inline"`
-		} `json:"message,omitempty"`
-		TraceId *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorTraceId)
-			ErrorTraceId `yaml:",inline"`
-		} `json:"trace_id,omitempty"`
-	} `json:"error,omitempty"`
+	// error
+	Error ErrorDetail `json:"error"`
 }
 
 // Error401 defines model for Error401.
 type Error401 struct {
-	// error 401
-	Error *struct {
-		Code *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorCode)
-			ErrorCode `yaml:",inline"`
-		} `json:"code,omitempty"`
-		Errors *struct {
-			// Embedded struct due to allOf(#/components/schemas/Errors)
-			Errors `yaml:",inline"`
-		} `json:"errors,omitempty"`
-		Message *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorMessage)
-			ErrorMessage `yaml:",inline"`
-		} `json:"message,omitempty"`
-		TraceId *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorTraceId)
-			ErrorTraceId `yaml:",inline"`
-		} `json:"trace_id,omitempty"`
-	} `json:"error,omitempty"`
+	// error
+	Error ErrorDetail `json:"error"`
 }
 
 // Error403 defines model for Error403.
 type Error403 struct {
-	// error 403
-	Error *struct {
-		Code *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorCode)
-			ErrorCode `yaml:",inline"`
-		} `json:"code,omitempty"`
-		Errors *struct {
-			// Embedded struct due to allOf(#/components/schemas/Errors)
-			Errors `yaml:",inline"`
-		} `json:"errors,omitempty"`
-		Message *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorMessage)
-			ErrorMessage `yaml:",inline"`
-		} `json:"message,omitempty"`
-		TraceId *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorTraceId)
-			ErrorTraceId `yaml:",inline"`
-		} `json:"trace_id,omitempty"`
-	} `json:"error,omitempty"`
+	// error
+	Error ErrorDetail `json:"error"`
 }
 
 // Error404 defines model for Error404.
 type Error404 struct {
-	// error 404
-	Error *struct {
-		Code *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorCode)
-			ErrorCode `yaml:",inline"`
-		} `json:"code,omitempty"`
-		Errors *struct {
-			// Embedded struct due to allOf(#/components/schemas/Errors)
-			Errors `yaml:",inline"`
-		} `json:"errors,omitempty"`
-		Message *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorMessage)
-			ErrorMessage `yaml:",inline"`
-		} `json:"message,omitempty"`
-		TraceId *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorTraceId)
-			ErrorTraceId `yaml:",inline"`
-		} `json:"trace_id,omitempty"`
-	} `json:"error,omitempty"`
+	// error
+	Error ErrorDetail `json:"error"`
 }
 
 // Error409 defines model for Error409.
 type Error409 struct {
-	// error 409
-	Error *struct {
-		Code *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorCode)
-			ErrorCode `yaml:",inline"`
-		} `json:"code,omitempty"`
-		Errors *struct {
-			// Embedded struct due to allOf(#/components/schemas/Errors)
-			Errors `yaml:",inline"`
-		} `json:"errors,omitempty"`
-		Message *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorMessage)
-			ErrorMessage `yaml:",inline"`
-		} `json:"message,omitempty"`
-		TraceId *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorTraceId)
-			ErrorTraceId `yaml:",inline"`
-		} `json:"trace_id,omitempty"`
-	} `json:"error,omitempty"`
+	// error
+	Error ErrorDetail `json:"error"`
 }
 
 // エラーコード。
@@ -196,25 +136,24 @@ type ErrorCode int32
 
 // ErrorDefault defines model for ErrorDefault.
 type ErrorDefault struct {
-	// error 500
-	Error *struct {
-		Code *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorCode)
-			ErrorCode `yaml:",inline"`
-		} `json:"code,omitempty"`
-		Errors *struct {
-			// Embedded struct due to allOf(#/components/schemas/Errors)
-			Errors `yaml:",inline"`
-		} `json:"errors,omitempty"`
-		Message *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorMessage)
-			ErrorMessage `yaml:",inline"`
-		} `json:"message,omitempty"`
-		TraceId *struct {
-			// Embedded struct due to allOf(#/components/schemas/ErrorTraceId)
-			ErrorTraceId `yaml:",inline"`
-		} `json:"trace_id,omitempty"`
-	} `json:"error,omitempty"`
+	// error
+	Error ErrorDetail `json:"error"`
+}
+
+// error
+type ErrorDetail struct {
+	// エラーコード。
+	Code ErrorCode `json:"code"`
+
+	// 認証に関するエラーについて詳細なエラー内容を表示する。
+	Errors Errors `json:"errors"`
+
+	// エラー発生時のメッセージ内容。
+	// このメッセージはエラーを発生させたアプリケーションのメッセージをそのまま含む場合がある。
+	Message ErrorMessage `json:"message"`
+
+	// X-Sakura-Internal-Serial-ID
+	TraceId ErrorTraceId `json:"trace_id"`
 }
 
 // エラー発生時のメッセージ内容。
@@ -225,28 +164,7 @@ type ErrorMessage string
 type ErrorTraceId string
 
 // 認証に関するエラーについて詳細なエラー内容を表示する。
-type Errors []struct {
-	Domain *struct {
-		// Embedded struct due to allOf(#/components/schemas/ErrorsDomain)
-		ErrorsDomain `yaml:",inline"`
-	} `json:"domain,omitempty"`
-	Location *struct {
-		// Embedded struct due to allOf(#/components/schemas/ErrorsLocation)
-		ErrorsLocation `yaml:",inline"`
-	} `json:"location,omitempty"`
-	LocationType *struct {
-		// Embedded struct due to allOf(#/components/schemas/ErrorsLocationType)
-		ErrorsLocationType `yaml:",inline"`
-	} `json:"location_type,omitempty"`
-	Message *struct {
-		// Embedded struct due to allOf(#/components/schemas/ErrorsMessage)
-		ErrorsMessage `yaml:",inline"`
-	} `json:"message,omitempty"`
-	Reason *struct {
-		// Embedded struct due to allOf(#/components/schemas/ErrorsReason)
-		ErrorsReason `yaml:",inline"`
-	} `json:"reason,omitempty"`
-}
+type Errors []Error
 
 // どのサービスで発生したエラーかを判別する。
 // マイクロサービス名に加えてクラスター名を含む文字列が入ることを想定している。


### PR DESCRIPTION
- swagger.yamlを修正
  - 各エラー型のフィールドがAnonymous structsにならないように内部エラー定義を切り出し
  - 各エラー型に対しrequiredの追加
- コードテンプレートを修正し各レスポンス型でResult()を使えるように
- レスポンス型でのResults()で必要なfunc類の実装

Note: 各レスポンス型での`Results()`は[phy-go](https://github.com/sacloud/phy-go)と同じ方式を採用
`Result()`によりエラーを統一的に扱えるようになる。

```go
	resp, err := client.ListClustersWithResponse(context.Background())
	if err != nil {
		panic(err)
	}

	sites, err := resp.Result()

	// Result()で返される値はJSON4XXといったエラーの型を意識せずに済む
	if err != nil {
		panic(err)
	}
```