### PR TITLE
高レベルAPI

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -1,0 +1,116 @@
+// Copyright 2022 The sacloud/object-storage-api-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstorage
+
+import (
+	"context"
+
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+// AccountAPI アカウント操作関連API
+type AccountAPI interface {
+	// Create アカウントの作成
+	Create(ctx context.Context, siteId string) (*v1.Account, error)
+	// Read アカウントの参照
+	Read(ctx context.Context, siteId string) (*v1.Account, error)
+	// Delete アカウントの削除
+	Delete(ctx context.Context, siteId string) error
+
+	// CreateAccessKey アクセスキーの作成
+	//
+	// Secretはこの戻り値でのみ参照可能
+	CreateAccessKey(ctx context.Context, siteId string) (*v1.AccountKey, error)
+	// ReadAccessKey アクセスキーの参照
+	//
+	// Secretは常に空文字になっている
+	ReadAccessKey(ctx context.Context, siteId, accessKeyId string) (*v1.AccountKey, error)
+	// DeleteAccessKey アクセスキーの削除
+	DeleteAccessKey(ctx context.Context, siteId, accessKeyId string) error
+}
+
+var _ AccountAPI = (*accountOp)(nil)
+
+type accountOp struct {
+	client *Client
+}
+
+func NewAccountOp(client *Client) AccountAPI {
+	return &accountOp{client: client}
+}
+
+func (op *accountOp) Create(ctx context.Context, siteId string) (*v1.Account, error) {
+	resp, err := op.client.apiClient().CreateSiteAccountWithResponse(ctx, siteId)
+	if err != nil {
+		return nil, err
+	}
+	account, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+	return &account.Data, nil
+}
+
+func (op *accountOp) Read(ctx context.Context, siteId string) (*v1.Account, error) {
+	resp, err := op.client.apiClient().ReadSiteAccountWithResponse(ctx, siteId)
+	if err != nil {
+		return nil, err
+	}
+	account, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+	return &account.Data, nil
+}
+
+func (op *accountOp) Delete(ctx context.Context, siteId string) error {
+	resp, err := op.client.apiClient().DeleteSiteAccountWithResponse(ctx, siteId)
+	if err != nil {
+		return err
+	}
+	return resp.Result()
+}
+
+func (op *accountOp) CreateAccessKey(ctx context.Context, siteId string) (*v1.AccountKey, error) {
+	resp, err := op.client.apiClient().CreateAccountAccessKeyWithResponse(ctx, siteId)
+	if err != nil {
+		return nil, err
+	}
+	account, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+	return &account.Data, nil
+}
+
+func (op *accountOp) ReadAccessKey(ctx context.Context, siteId, accessKeyId string) (*v1.AccountKey, error) {
+	resp, err := op.client.apiClient().ReadAccountAccessKeyWithResponse(ctx, siteId, v1.AccessKeyID(accessKeyId))
+	if err != nil {
+		return nil, err
+	}
+	account, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+	return &account.Data, nil
+}
+
+func (op *accountOp) DeleteAccessKey(ctx context.Context, siteId, accessKeyId string) error {
+	resp, err := op.client.apiClient().DeleteAccountAccessKeyWithResponse(ctx, siteId, v1.AccessKeyID(accessKeyId))
+	if err != nil {
+		return err
+	}
+	return resp.Result()
+}

--- a/apis/v1/aliases.go
+++ b/apis/v1/aliases.go
@@ -1,0 +1,19 @@
+// Copyright 2022 The sacloud/object-storage-api-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+type CreatePermissionParams = CreatePermissionJSONRequestBody
+
+type UpdatePermissionParams = UpdatePermissionJSONRequestBody

--- a/apis/v1/errors.go
+++ b/apis/v1/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 The phy-go authors
+// Copyright 2022 The sacloud/object-storage-api-go authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/v1/example_fake_test.go
+++ b/apis/v1/example_fake_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 The phy-go authors
+// Copyright 2022 The sacloud/object-storage-api-go authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/v1/example_test.go
+++ b/apis/v1/example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 The phy-go authors
+// Copyright 2022 The sacloud/object-storage-api-go authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/v1/functions.go
+++ b/apis/v1/functions.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 The phy-go authors
+// Copyright 2022 The sacloud/object-storage-api-go authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/v1/interceptors.go
+++ b/apis/v1/interceptors.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 The phy-go authors
+// Copyright 2022 The sacloud/object-storage-api-go authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buckets.go
+++ b/buckets.go
@@ -1,0 +1,67 @@
+// Copyright 2022 The sacloud/object-storage-api-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstorage
+
+import (
+	"context"
+
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+// BucketAPI バケット操作関連API
+type BucketAPI interface {
+	// Create バケットの作成
+	Create(ctx context.Context, siteId, bucketName string) (*v1.Bucket, error)
+	// Delete バケットの削除
+	Delete(ctx context.Context, siteId, bucketName string) error
+}
+
+var _ BucketAPI = (*bucketOp)(nil)
+
+type bucketOp struct {
+	client *Client
+}
+
+func NewBucketOp(client *Client) BucketAPI {
+	return &bucketOp{client: client}
+}
+
+func (op *bucketOp) Create(ctx context.Context, siteId, bucketName string) (*v1.Bucket, error) {
+	params := v1.CreateBucketJSONRequestBody{
+		ClusterId: siteId,
+	}
+
+	resp, err := op.client.apiClient().CreateBucketWithResponse(ctx, v1.BucketName(bucketName), params)
+	if err != nil {
+		return nil, err
+	}
+	bucket, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+	return &bucket.Data, nil
+}
+
+func (op *bucketOp) Delete(ctx context.Context, siteId, bucketName string) error {
+	params := v1.DeleteBucketJSONRequestBody{
+		ClusterId: siteId,
+	}
+
+	resp, err := op.client.apiClient().DeleteBucketWithResponse(ctx, v1.BucketName(bucketName), params)
+	if err != nil {
+		return err
+	}
+	return resp.Result()
+}

--- a/client.go
+++ b/client.go
@@ -33,7 +33,7 @@ const DefaultAPIRootURL = "https://secure.sakura.ad.jp/cloud/zone/is1a/api/objec
 
 // UserAgent APIリクエスト時のユーザーエージェント
 var UserAgent = fmt.Sprintf(
-	"phy-go/%s (%s/%s; +https://github.com/sacloud/object-storage-api-go) %s",
+	"object-storage-api-go/%s (%s/%s; +https://github.com/sacloud/object-storage-api-go) %s",
 	Version,
 	runtime.GOOS,
 	runtime.GOARCH,

--- a/client.go
+++ b/client.go
@@ -1,0 +1,124 @@
+// Copyright 2022 The sacloud/object-storage-api-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstorage
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/go-retryablehttp"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+
+	sacloudhttp "github.com/sacloud/go-http"
+)
+
+// DefaultAPIRootURL デフォルトのAPIルートURL
+const DefaultAPIRootURL = "https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0"
+
+// UserAgent APIリクエスト時のユーザーエージェント
+var UserAgent = fmt.Sprintf(
+	"phy-go/%s (%s/%s; +https://github.com/sacloud/object-storage-api-go) %s",
+	Version,
+	runtime.GOOS,
+	runtime.GOARCH,
+	sacloudhttp.DefaultUserAgent,
+)
+
+// Client APIクライアント
+type Client struct {
+	// Token APIキー: トークン
+	Token string
+	// Token APIキー: シークレット
+	Secret string
+
+	// AcceptLanguage APIリクエスト時のAccept-Languageヘッダーの値
+	AcceptLanguage string
+
+	// Gzip APIリクエストでgzipを有効にするかのフラグ
+	Gzip bool
+
+	// APIRootURL APIのリクエスト先URLプレフィックス、省略可能
+	APIRootURL string
+
+	// Trace トレースログ出力フラグ
+	Trace bool
+
+	// HTTPClient APIリクエストで使用されるHTTPクライアント
+	//
+	// 省略した場合はhttp.DefaultClientが使用される
+	HTTPClient *http.Client
+
+	initOnce sync.Once
+}
+
+func (c *Client) serverURL() string {
+	v := DefaultAPIRootURL
+	if c.APIRootURL != "" {
+		v = c.APIRootURL
+	}
+	if !strings.HasSuffix(v, "/") {
+		v += "/"
+	}
+	return v
+}
+
+func (c *Client) httpClient() *http.Client {
+	client := http.DefaultClient
+	if c.HTTPClient != nil {
+		client = c.HTTPClient
+	}
+
+	c.initOnce.Do(func() {
+		if c.Trace {
+			client.Transport = &sacloudhttp.TracingRoundTripper{
+				Transport: client.Transport,
+			}
+		}
+	})
+	return client
+}
+
+func (c *Client) apiClient() *v1.ClientWithResponses {
+	httpClient := &sacloudhttp.Client{
+		AccessToken:       c.Token,
+		AccessTokenSecret: c.Secret,
+		UserAgent:         UserAgent,
+		AcceptLanguage:    c.AcceptLanguage,
+		Gzip:              c.Gzip,
+		CheckRetryFunc: func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+			if ctx.Err() != nil {
+				return false, ctx.Err()
+			}
+			if err != nil {
+				return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+			}
+			if resp.StatusCode == 0 { // ステータスコードに応じてリトライしたい場合はここで対応
+				return true, nil
+			}
+			return false, nil
+		},
+		HTTPClient: c.httpClient(),
+	}
+	return &v1.ClientWithResponses{
+		ClientInterface: &v1.Client{
+			Server: c.serverURL(),
+			Client: httpClient,
+		},
+	}
+}

--- a/example_fake_test.go
+++ b/example_fake_test.go
@@ -1,0 +1,65 @@
+// Copyright 2021-2022 The phy-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstorage_test
+
+import (
+	"net/http/httptest"
+	"time"
+
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+	"github.com/sacloud/object-storage-api-go/fake"
+	"github.com/sacloud/object-storage-api-go/fake/server"
+)
+
+func init() {
+	initFakeServer()
+}
+
+func initFakeServer() {
+	siteId := "isk01"
+	fakeServer := &server.Server{
+		Engine: &fake.Engine{
+			Clusters: []*v1.Cluster{
+				{
+					Id: siteId,
+
+					ControlPanelUrl: "https://secure.sakura.ad.jp/objectstorage/",
+					DislpayNameEnUs: "Ishikari Site #1",
+					DislpayNameJa:   "石狩第1サイト",
+					DisplayName:     "石狩第1サイト",
+					DisplayOrder:    1,
+					EndpointBase:    "isk01.sakurastorage.jp",
+				},
+			},
+			Account: &v1.Account{
+				Code:       "member@account@isk01",
+				CreatedAt:  v1.CreatedAt(time.Now()),
+				ResourceId: "100000000001",
+			},
+			Buckets: []*v1.Bucket{
+				{
+					ClusterId: siteId,
+					Name:      "bucket1",
+				},
+				{
+					ClusterId: siteId,
+					Name:      "bucket2",
+				},
+			},
+		},
+	}
+	sv := httptest.NewServer(fakeServer.Handler())
+	serverURL = sv.URL
+}

--- a/example_fake_test.go
+++ b/example_fake_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 The phy-go authors
+// Copyright 2022 The sacloud/object-storage-api-go authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,224 @@
+// Copyright 2021-2022 The phy-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstorage_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+)
+
+var serverURL = "https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0"
+
+// Example_clusterAPI サイト(クラスタ)APIの利用例
+func Example_clusterAPI() {
+	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
+	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
+
+	client := &objectstorage.Client{
+		Token:      token,
+		Secret:     secret,
+		APIRootURL: serverURL, // 省略可能
+	}
+
+	// サイト一覧の取得
+	siteOp := objectstorage.NewSiteOp(client)
+	sites, err := siteOp.List(context.Background())
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(sites[0].DisplayName)
+	// output:
+	// 石狩第1サイト
+}
+
+// Example_bucketAPI バケットAPIの利用例
+func Example_bucketAPI() {
+	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
+	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
+
+	client := &objectstorage.Client{
+		Token:      token,
+		Secret:     secret,
+		APIRootURL: serverURL, // 省略可能
+	}
+	ctx := context.Background()
+
+	// サイトIDが必要なため取得しておく
+	siteOp := objectstorage.NewSiteOp(client)
+	sites, err := siteOp.List(ctx)
+	if err != nil {
+		panic(err)
+	}
+	siteId := sites[0].Id
+
+	// バケットの作成
+	bucketName := "your-bucket-name"
+	bucketAPI := objectstorage.NewBucketOp(client)
+	bucket, err := bucketAPI.Create(ctx, siteId, bucketName)
+	if err != nil {
+		panic(err)
+	}
+
+	// バケットの削除
+	defer func() {
+		if err := bucketAPI.Delete(ctx, siteId, bucketName); err != nil {
+			panic(err)
+		}
+	}()
+
+	fmt.Println(bucket.Name)
+	// output:
+	// your-bucket-name
+}
+
+// Example_accountAPI アカウントAPIの利用例
+func Example_accountAPI() {
+	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
+	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
+
+	client := &objectstorage.Client{
+		Token:      token,
+		Secret:     secret,
+		APIRootURL: serverURL, // 省略可能
+	}
+	ctx := context.Background()
+
+	// サイトIDが必要なため取得しておく
+	siteOp := objectstorage.NewSiteOp(client)
+	sites, err := siteOp.List(ctx)
+	if err != nil {
+		panic(err)
+	}
+	siteId := sites[0].Id
+
+	// アカウントの参照
+	accountOp := objectstorage.NewAccountOp(client)
+	account, err := accountOp.Read(ctx, siteId)
+	if err != nil {
+		panic(err)
+	}
+
+	// アクセスキーの作成
+	accessKey, err := accountOp.CreateAccessKey(ctx, siteId)
+	if err != nil {
+		panic(err)
+	}
+
+	// アクセスキーの削除
+	defer func() {
+		if err := accountOp.DeleteAccessKey(ctx, siteId, accessKey.Id.String()); err != nil {
+			panic(err)
+		}
+	}()
+
+	fmt.Printf("AccountCode: %s, Secret: %s", account.Code, accessKey.Secret)
+	// output:
+	// AccountCode: member@account@isk01, Secret: secret
+}
+
+// Example_permissionAPI パーミッションAPIの利用例
+func Example_permissionAPI() {
+	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
+	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
+
+	client := &objectstorage.Client{
+		Token:      token,
+		Secret:     secret,
+		APIRootURL: serverURL, // 省略可能
+	}
+	ctx := context.Background()
+
+	// サイトIDが必要なため取得しておく
+	siteOp := objectstorage.NewSiteOp(client)
+	sites, err := siteOp.List(ctx)
+	if err != nil {
+		panic(err)
+	}
+	siteId := sites[0].Id
+
+	// パーミッションの作成
+	permissionOp := objectstorage.NewPermissionOp(client)
+	permission, err := permissionOp.Create(ctx, siteId, &v1.CreatePermissionParams{
+		BucketControls: v1.BucketControls{
+			{
+				BucketName: "bucket1",
+				CanRead:    true,
+				CanWrite:   true,
+			},
+		},
+		DisplayName: "foobar",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// アクセスキーの作成
+	accessKey, err := permissionOp.CreateAccessKey(ctx, siteId, permission.Id.Int64())
+	if err != nil {
+		panic(err)
+	}
+
+	// パーミッション/アクセスキーの削除
+	defer func() {
+		if err := permissionOp.DeleteAccessKey(ctx, siteId, permission.Id.Int64(), accessKey.Id.String()); err != nil {
+			panic(err)
+		}
+		if err := permissionOp.Delete(ctx, siteId, permission.Id.Int64()); err != nil {
+			panic(err)
+		}
+	}()
+
+	fmt.Printf("Permission: %s, Secret: %s", permission.DisplayName, accessKey.Secret)
+	// output:
+	// Permission: foobar, Secret: secret
+}
+
+// Example_siteStatusAPI サイトステータスAPIの利用例
+func Example_siteStatusAPI() {
+	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
+	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
+
+	client := &objectstorage.Client{
+		Token:      token,
+		Secret:     secret,
+		APIRootURL: serverURL, // 省略可能
+	}
+	ctx := context.Background()
+
+	// サイトIDが必要なため取得しておく
+	siteOp := objectstorage.NewSiteOp(client)
+	sites, err := siteOp.List(ctx)
+	if err != nil {
+		panic(err)
+	}
+	siteId := sites[0].Id
+
+	// サイトステータスの参照
+	statusOp := objectstorage.NewSiteStatusOp(client)
+	status, err := statusOp.Read(ctx, siteId)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(status.StatusCode.Status)
+	// output:
+	// ok
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 The phy-go authors
+// Copyright 2022 The sacloud/object-storage-api-go authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/fake/buckets_test.go
+++ b/fake/buckets_test.go
@@ -48,14 +48,14 @@ func TestEngine_Buckets(t *testing.T) {
 	}
 
 	t.Run("create bucket", func(t *testing.T) {
-		bucket, err := engine.CreateBucket("foobar")
+		bucket, err := engine.CreateBucket("isk01", "foobar")
 		require.NoError(t, err)
 		require.Equal(t, &v1.Bucket{ClusterId: "isk01", Name: "foobar"}, bucket)
 		require.Len(t, engine.Buckets, 3)
 	})
 
 	t.Run("delete bucket", func(t *testing.T) {
-		err := engine.DeleteBucket("foobar")
+		err := engine.DeleteBucket("isk01", "foobar")
 		require.NoError(t, err)
 		require.Len(t, engine.Buckets, 2)
 		require.Equal(t, engine.Buckets[0].Name, "bucket1")

--- a/fake/permissions.go
+++ b/fake/permissions.go
@@ -24,10 +24,10 @@ import (
 
 // ListPermissions パーミッション一覧の取得
 // (GET /{site_name}/v2/permissions)
-func (engine *Engine) ListPermissions(siteName string) ([]v1.Permission, error) {
+func (engine *Engine) ListPermissions(siteId string) ([]v1.Permission, error) {
 	defer engine.rLock()()
 
-	if err := engine.siteExist(siteName); err != nil {
+	if err := engine.siteExist(siteId); err != nil {
 		return nil, err
 	}
 	return engine.permissions(), nil
@@ -35,10 +35,10 @@ func (engine *Engine) ListPermissions(siteName string) ([]v1.Permission, error) 
 
 // CreatePermission パーミッションの作成
 // (POST /{site_name}/v2/permissions)
-func (engine *Engine) CreatePermission(siteName string, params *v1.PermissionRequestBody) (*v1.Permission, error) {
+func (engine *Engine) CreatePermission(siteId string, params *v1.PermissionRequestBody) (*v1.Permission, error) {
 	defer engine.lock()()
 
-	if err := engine.siteExist(siteName); err != nil {
+	if err := engine.siteExist(siteId); err != nil {
 		return nil, err
 	}
 
@@ -55,10 +55,10 @@ func (engine *Engine) CreatePermission(siteName string, params *v1.PermissionReq
 
 // DeletePermission パーミッションの削除
 // (DELETE /{site_name}/v2/permissions/{id})
-func (engine *Engine) DeletePermission(siteName string, permissionId int64) error {
+func (engine *Engine) DeletePermission(siteId string, permissionId int64) error {
 	defer engine.lock()()
 
-	if err := engine.siteAndPermissionExist(siteName, permissionId); err != nil {
+	if err := engine.siteAndPermissionExist(siteId, permissionId); err != nil {
 		return err
 	}
 
@@ -74,10 +74,10 @@ func (engine *Engine) DeletePermission(siteName string, permissionId int64) erro
 
 // ReadPermission パーミッションの取得
 // (GET /{site_name}/v2/permissions/{id})
-func (engine *Engine) ReadPermission(siteName string, permissionId int64) (*v1.Permission, error) {
+func (engine *Engine) ReadPermission(siteId string, permissionId int64) (*v1.Permission, error) {
 	defer engine.rLock()()
 
-	if err := engine.siteAndPermissionExist(siteName, permissionId); err != nil {
+	if err := engine.siteAndPermissionExist(siteId, permissionId); err != nil {
 		return nil, err
 	}
 
@@ -86,10 +86,10 @@ func (engine *Engine) ReadPermission(siteName string, permissionId int64) (*v1.P
 
 // UpdatePermission パーミッションの更新
 // (PUT /{site_name}/v2/permissions/{id})
-func (engine *Engine) UpdatePermission(siteName string, permissionId int64, params *v1.PermissionRequestBody) (*v1.Permission, error) {
+func (engine *Engine) UpdatePermission(siteId string, permissionId int64, params *v1.PermissionRequestBody) (*v1.Permission, error) {
 	defer engine.lock()()
 
-	if err := engine.siteAndPermissionExist(siteName, permissionId); err != nil {
+	if err := engine.siteAndPermissionExist(siteId, permissionId); err != nil {
 		return nil, err
 	}
 

--- a/fake/server/buckets.go
+++ b/fake/server/buckets.go
@@ -24,7 +24,12 @@ import (
 // DeleteBucket バケットの削除
 // (DELETE /fed/v1/buckets/{name})
 func (s *Server) DeleteBucket(c *gin.Context, bucketName v1.BucketName) {
-	if err := s.Engine.DeleteBucket(bucketName.String()); err != nil {
+	var paramJSON v1.DeleteBucketJSONRequestBody
+	if err := c.ShouldBindJSON(&paramJSON); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := s.Engine.DeleteBucket(paramJSON.ClusterId, bucketName.String()); err != nil {
 		s.handleError(c, err)
 		return
 	}
@@ -35,7 +40,13 @@ func (s *Server) DeleteBucket(c *gin.Context, bucketName v1.BucketName) {
 // CreateBucket バケットの作成
 // (PUT /fed/v1/buckets/{name})
 func (s *Server) CreateBucket(c *gin.Context, bucketName v1.BucketName) {
-	bucket, err := s.Engine.CreateBucket(bucketName.String())
+	var paramJSON v1.CreateBucketJSONRequestBody
+	if err := c.ShouldBindJSON(&paramJSON); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	bucket, err := s.Engine.CreateBucket(paramJSON.ClusterId, bucketName.String())
 	if err != nil {
 		s.handleError(c, err)
 		return

--- a/go.mod
+++ b/go.mod
@@ -11,12 +11,15 @@ require (
 )
 
 require (
+	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator/v10 v10.9.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
@@ -24,8 +27,10 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sacloud/go-http v0.0.4 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/ugorji/go/codec v1.2.6 // indirect
+	go.uber.org/ratelimit v0.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -228,7 +230,9 @@ github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOj
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -237,6 +241,8 @@ github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
+github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
+github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
@@ -359,6 +365,8 @@ github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUA
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/sacloud/go-http v0.0.4 h1:+vgx/uCctcGiHMe8jE+qirMKd3+d73MNZXK7nrUo0po=
+github.com/sacloud/go-http v0.0.4/go.mod h1:aYTXNuAnPmD6Ar3ktDaR1gPxJCPv2CqpppcYciy1hmo=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -410,6 +418,8 @@ go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
+go.uber.org/ratelimit v0.2.0 h1:UQE2Bgi7p2B85uP5dC2bbRtig0C+OeNRnNEafLjsLPA=
+go.uber.org/ratelimit v0.2.0/go.mod h1:YYBV4e4naJvhpitQrWJu1vCpgB7CboMe0qhltKt6mUg=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/permissions.go
+++ b/permissions.go
@@ -1,0 +1,167 @@
+// Copyright 2022 The sacloud/object-storage-api-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstorage
+
+import (
+	"context"
+
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+type PermissionAPI interface {
+	List(ctx context.Context, siteId string) ([]*v1.Permission, error)
+	// Create パーミッションの作成
+	Create(ctx context.Context, siteId string, params *v1.CreatePermissionParams) (*v1.Permission, error)
+	// Read パーミッションの参照
+	Read(ctx context.Context, siteId string, permissionId int64) (*v1.Permission, error)
+	// Update パーミッションの更新
+	Update(ctx context.Context, siteId string, permissionId int64, params *v1.UpdatePermissionParams) (*v1.Permission, error)
+	// Delete パーミッションの削除
+	Delete(ctx context.Context, siteId string, permissionId int64) error
+
+	// ListAccessKeys アクセスキー一覧
+	ListAccessKeys(ctx context.Context, siteId string, permissionId int64) ([]*v1.PermissionKey, error)
+	// CreateAccessKey アクセスキーの作成
+	//
+	// Secretはこの戻り値でのみ参照可能
+	CreateAccessKey(ctx context.Context, siteId string, permissionId int64) (*v1.PermissionKey, error)
+	// ReadAccessKey アクセスキーの参照
+	//
+	// Secretは常に空文字になっている
+	ReadAccessKey(ctx context.Context, siteId string, permissonId int64, accessKeyId string) (*v1.PermissionKey, error)
+	// DeleteAccessKey アクセスキーの削除
+	DeleteAccessKey(ctx context.Context, siteId string, permissionId int64, accessKeyId string) error
+}
+
+var _ PermissionAPI = (*permissionOp)(nil)
+
+type permissionOp struct {
+	client *Client
+}
+
+func NewPermissionOp(client *Client) PermissionAPI {
+	return &permissionOp{client: client}
+}
+
+func (op *permissionOp) List(ctx context.Context, siteId string) ([]*v1.Permission, error) {
+	resp, err := op.client.apiClient().ListPermissionsWithResponse(ctx, siteId)
+	if err != nil {
+		return nil, err
+	}
+	permissions, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+	var results []*v1.Permission
+	for _, p := range permissions.Data {
+		results = append(results, &p)
+	}
+	return results, nil
+}
+
+func (op *permissionOp) Create(ctx context.Context, siteId string, params *v1.CreatePermissionParams) (*v1.Permission, error) {
+	resp, err := op.client.apiClient().CreatePermissionWithResponse(ctx, siteId, v1.CreatePermissionJSONRequestBody(*params))
+	if err != nil {
+		return nil, err
+	}
+	permission, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+	return &permission.Data, nil
+}
+
+func (op *permissionOp) Read(ctx context.Context, siteId string, permissionId int64) (*v1.Permission, error) {
+	resp, err := op.client.apiClient().ReadPermissionWithResponse(ctx, siteId, v1.PermissionID(permissionId))
+	if err != nil {
+		return nil, err
+	}
+	permission, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+	return &permission.Data, nil
+}
+
+func (op *permissionOp) Update(ctx context.Context, siteId string, permissionId int64, params *v1.UpdatePermissionParams) (*v1.Permission, error) {
+	resp, err := op.client.apiClient().UpdatePermissionWithResponse(ctx, siteId,
+		v1.PermissionID(permissionId), v1.UpdatePermissionJSONRequestBody(*params))
+	if err != nil {
+		return nil, err
+	}
+	permission, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+	return &permission.Data, nil
+}
+
+func (op *permissionOp) Delete(ctx context.Context, siteId string, permissionId int64) error {
+	resp, err := op.client.apiClient().DeletePermissionWithResponse(ctx, siteId, v1.PermissionID(permissionId))
+	if err != nil {
+		return err
+	}
+	return resp.Result()
+}
+
+func (op *permissionOp) ListAccessKeys(ctx context.Context, siteId string, permissionId int64) ([]*v1.PermissionKey, error) {
+	resp, err := op.client.apiClient().ListPermissionAccessKeysWithResponse(ctx, siteId, v1.PermissionID(permissionId))
+	if err != nil {
+		return nil, err
+	}
+	permissions, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+	var results []*v1.PermissionKey
+	for _, p := range permissions.Data {
+		results = append(results, &p)
+	}
+	return results, nil
+}
+
+func (op *permissionOp) CreateAccessKey(ctx context.Context, siteId string, permissionId int64) (*v1.PermissionKey, error) {
+	resp, err := op.client.apiClient().CreatePermissionAccessKeyWithResponse(ctx, siteId, v1.PermissionID(permissionId))
+	if err != nil {
+		return nil, err
+	}
+	key, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+	return &key.Data, nil
+}
+
+func (op *permissionOp) ReadAccessKey(ctx context.Context, siteId string, permissionId int64, accessKeyId string) (*v1.PermissionKey, error) {
+	resp, err := op.client.apiClient().ReadPermissionAccessKeyWithResponse(ctx, siteId,
+		v1.PermissionID(permissionId), v1.AccessKeyID(accessKeyId))
+	if err != nil {
+		return nil, err
+	}
+	key, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+	return &key.Data, nil
+}
+
+func (op *permissionOp) DeleteAccessKey(ctx context.Context, siteId string, permissionId int64, accessKeyId string) error {
+	resp, err := op.client.apiClient().DeletePermissionAccessKeyWithResponse(ctx, siteId,
+		v1.PermissionID(permissionId), v1.AccessKeyID(accessKeyId))
+	if err != nil {
+		return err
+	}
+	return resp.Result()
+}

--- a/site_status.go
+++ b/site_status.go
@@ -1,0 +1,49 @@
+// Copyright 2022 The sacloud/object-storage-api-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstorage
+
+import (
+	"context"
+
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+// SiteStatusAPI サイトステータスAPI
+type SiteStatusAPI interface {
+	// Read サイトステータスの参照
+	Read(ctx context.Context, siteId string) (*v1.Status, error)
+}
+
+var _ SiteStatusAPI = (*siteStatusOp)(nil)
+
+type siteStatusOp struct {
+	client *Client
+}
+
+func NewSiteStatusOp(client *Client) SiteStatusAPI {
+	return &siteStatusOp{client: client}
+}
+
+func (op *siteStatusOp) Read(ctx context.Context, siteId string) (*v1.Status, error) {
+	resp, err := op.client.apiClient().ReadSiteStatusWithResponse(ctx, siteId)
+	if err != nil {
+		return nil, err
+	}
+	status, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+	return &status.Data, nil
+}

--- a/sites.go
+++ b/sites.go
@@ -1,0 +1,68 @@
+// Copyright 2022 The sacloud/object-storage-api-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstorage
+
+import (
+	"context"
+
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+// SiteAPI サイト(クラスター)関連API
+type SiteAPI interface {
+	// List サイト一覧
+	List(ctx context.Context) ([]*v1.Cluster, error)
+	// Read サイト詳細
+	Read(ctx context.Context, siteId string) (*v1.Cluster, error)
+}
+
+var _ SiteAPI = (*siteOp)(nil)
+
+type siteOp struct {
+	client *Client
+}
+
+func NewSiteOp(client *Client) SiteAPI {
+	return &siteOp{client: client}
+}
+
+func (op *siteOp) List(ctx context.Context) ([]*v1.Cluster, error) {
+	resp, err := op.client.apiClient().ListClustersWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	clusters, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*v1.Cluster
+	for _, c := range clusters.Data {
+		results = append(results, &c)
+	}
+	return results, nil
+}
+
+func (op *siteOp) Read(ctx context.Context, id string) (*v1.Cluster, error) {
+	resp, err := op.client.apiClient().ReadClusterWithResponse(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	cluster, err := resp.Result()
+	if err != nil {
+		return nil, err
+	}
+	return cluster.Data, nil
+}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 The phy-go authors
+// Copyright 2022 The sacloud/object-storage-api-go authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
oapi-codegenで生成されたコードをラップしより使いやすくした高レベルAPIを提供する。

- SiteAPI: サイト(クラスタ)関連API
- BucketAPI: バケット操作API
- AccountAPI: アカウント/アクセスキー関連API
- PermissionAPI: パーミッション/アクセスキー関連API
- SiteStatusAPI: サイトステータスAPI

利用例:

```go
// Example_clusterAPI サイト(クラスタ)APIの利用例
func Example_clusterAPI() {
	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")

	client := &objectstorage.Client{
		Token:      token,
		Secret:     secret,
		APIRootURL: serverURL, // 省略可能
	}

	// サイト一覧の取得
	siteOp := objectstorage.NewSiteOp(client)
	sites, err := siteOp.List(context.Background())
	if err != nil {
		panic(err)
	}

	fmt.Println(sites[0].DisplayName)
	// output:
	// 石狩第1サイト
}
```

参考: 生成されたコードを直接使う場合との比較

```go
// 同等の処理をoapi-codegenが生成したコードを直接使って行う場合
func Example_basic() {
	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")

	client, err := v1.NewClientWithResponses(serverURL, func(c *v1.Client) error {
		c.RequestEditors = []v1.RequestEditorFn{
			v1.OjsAuthInterceptor(token, secret),
		}
		return nil
	})
	if err != nil {
		panic(err)
	}

	resp, err := client.ListClustersWithResponse(context.Background())
	if err != nil {
		panic(err)
	}

	sites, err := resp.Result()
	if err != nil {
		panic(err)
	}

	site := sites.Data[0]
	fmt.Println(site.DisplayName)
	// output:
	// 石狩第1サイト
}
```