### PR TITLE
オリジナルswagger.jsonの更新反映

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -53,7 +53,7 @@ func NewAccountOp(client *Client) AccountAPI {
 }
 
 func (op *accountOp) Create(ctx context.Context, siteId string) (*v1.Account, error) {
-	resp, err := op.client.apiClient().CreateSiteAccountWithResponse(ctx, siteId)
+	resp, err := op.client.apiClient().CreateAccountWithResponse(ctx, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (op *accountOp) Create(ctx context.Context, siteId string) (*v1.Account, er
 }
 
 func (op *accountOp) Read(ctx context.Context, siteId string) (*v1.Account, error) {
-	resp, err := op.client.apiClient().ReadSiteAccountWithResponse(ctx, siteId)
+	resp, err := op.client.apiClient().GetAccountWithResponse(ctx, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (op *accountOp) Read(ctx context.Context, siteId string) (*v1.Account, erro
 }
 
 func (op *accountOp) Delete(ctx context.Context, siteId string) error {
-	resp, err := op.client.apiClient().DeleteSiteAccountWithResponse(ctx, siteId)
+	resp, err := op.client.apiClient().DeleteAccountWithResponse(ctx, siteId)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func (op *accountOp) Delete(ctx context.Context, siteId string) error {
 }
 
 func (op *accountOp) CreateAccessKey(ctx context.Context, siteId string) (*v1.AccountKey, error) {
-	resp, err := op.client.apiClient().CreateAccountAccessKeyWithResponse(ctx, siteId)
+	resp, err := op.client.apiClient().CreateAccountKeyWithResponse(ctx, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (op *accountOp) CreateAccessKey(ctx context.Context, siteId string) (*v1.Ac
 }
 
 func (op *accountOp) ReadAccessKey(ctx context.Context, siteId, accessKeyId string) (*v1.AccountKey, error) {
-	resp, err := op.client.apiClient().ReadAccountAccessKeyWithResponse(ctx, siteId, v1.AccessKeyID(accessKeyId))
+	resp, err := op.client.apiClient().GetAccountKeyWithResponse(ctx, siteId, v1.AccessKeyID(accessKeyId))
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (op *accountOp) ReadAccessKey(ctx context.Context, siteId, accessKeyId stri
 }
 
 func (op *accountOp) DeleteAccessKey(ctx context.Context, siteId, accessKeyId string) error {
-	resp, err := op.client.apiClient().DeleteAccountAccessKeyWithResponse(ctx, siteId, v1.AccessKeyID(accessKeyId))
+	resp, err := op.client.apiClient().DeleteAccountKeyWithResponse(ctx, siteId, v1.AccessKeyID(accessKeyId))
 	if err != nil {
 		return err
 	}

--- a/apis/v1/example_fake_test.go
+++ b/apis/v1/example_fake_test.go
@@ -36,8 +36,8 @@ func initFakeServer() {
 					Id: siteId,
 
 					ControlPanelUrl: "https://secure.sakura.ad.jp/objectstorage/",
-					DislpayNameEnUs: "Ishikari Site #1",
-					DislpayNameJa:   "石狩第1サイト",
+					DisplayNameEnUs: "Ishikari Site #1",
+					DisplayNameJa:   "石狩第1サイト",
 					DisplayName:     "石狩第1サイト",
 					DisplayOrder:    1,
 					EndpointBase:    "isk01.sakurastorage.jp",

--- a/apis/v1/example_test.go
+++ b/apis/v1/example_test.go
@@ -39,7 +39,7 @@ func Example_basic() {
 		panic(err)
 	}
 
-	resp, err := client.ListClustersWithResponse(context.Background())
+	resp, err := client.GetClustersWithResponse(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -71,7 +71,7 @@ func Example_readSiteAccount() {
 	}
 
 	// サイトIDが必要になるためまずサイト一覧を取得
-	sitesResp, err := client.ListClustersWithResponse(context.Background())
+	sitesResp, err := client.GetClustersWithResponse(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -83,7 +83,7 @@ func Example_readSiteAccount() {
 	siteId := sites.Data[0].Id
 
 	// サイトアカウントの参照
-	accountResp, err := client.ReadSiteAccountWithResponse(context.Background(), siteId)
+	accountResp, err := client.GetAccountWithResponse(context.Background(), siteId)
 	if err != nil {
 		panic(err)
 	}
@@ -114,7 +114,7 @@ func Example_siteAccountKeys() {
 	}
 
 	// サイトIDが必要になるためまずサイト一覧を取得
-	sitesResp, err := client.ListClustersWithResponse(context.Background())
+	sitesResp, err := client.GetClustersWithResponse(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -126,7 +126,7 @@ func Example_siteAccountKeys() {
 	siteId := sites.Data[0].Id
 
 	// サイトアカウントのキーを作成
-	keyResp, err := client.CreateAccountAccessKeyWithResponse(context.Background(), siteId)
+	keyResp, err := client.CreateAccountKeyWithResponse(context.Background(), siteId)
 	if err != nil {
 		panic(err)
 	}
@@ -157,7 +157,7 @@ func Example_bucket() {
 	}
 
 	// サイトIDが必要になるためまずサイト一覧を取得
-	sitesResp, err := client.ListClustersWithResponse(context.Background())
+	sitesResp, err := client.GetClustersWithResponse(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -217,7 +217,7 @@ func Example_permissions() {
 	}
 
 	// サイトIDが必要になるためまずサイト一覧を取得
-	sitesResp, err := client.ListClustersWithResponse(context.Background())
+	sitesResp, err := client.GetClustersWithResponse(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -279,7 +279,7 @@ func Example_permissionKeys() {
 	}
 
 	// サイトIDが必要になるためまずサイト一覧を取得
-	sitesResp, err := client.ListClustersWithResponse(context.Background())
+	sitesResp, err := client.GetClustersWithResponse(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -311,7 +311,7 @@ func Example_permissionKeys() {
 	}
 
 	// パーミッションのキーを作成
-	keyResp, err := client.CreatePermissionAccessKeyWithResponse(context.Background(), siteId, permission.Data.Id)
+	keyResp, err := client.CreatePermissionKeyWithResponse(context.Background(), siteId, permission.Data.Id)
 	if err != nil {
 		panic(err)
 	}
@@ -322,7 +322,7 @@ func Example_permissionKeys() {
 	}
 
 	defer func() {
-		keyDeleteResp, err := client.DeletePermissionAccessKeyWithResponse(context.Background(), siteId, permission.Data.Id, key.Data.Id)
+		keyDeleteResp, err := client.DeletePermissionKeyWithResponse(context.Background(), siteId, permission.Data.Id, key.Data.Id)
 		if err != nil {
 			panic(err)
 		}
@@ -360,7 +360,7 @@ func Example_siteStatus() {
 	}
 
 	// サイトIDが必要になるためまずサイト一覧を取得
-	sitesResp, err := client.ListClustersWithResponse(context.Background())
+	sitesResp, err := client.GetClustersWithResponse(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -371,7 +371,7 @@ func Example_siteStatus() {
 	}
 	siteId := sites.Data[0].Id
 
-	statusResp, err := client.ReadSiteStatusWithResponse(context.Background(), siteId)
+	statusResp, err := client.GetStatusWithResponse(context.Background(), siteId)
 	if err != nil {
 		panic(err)
 	}

--- a/apis/v1/spec/README.md
+++ b/apis/v1/spec/README.md
@@ -3,7 +3,7 @@
 オリジナルの定義ファイルは以下のサイトで公開されています。
 [https://manual.sakura.ad.jp/cloud/objectstorage/api/api-json.html](https://manual.sakura.ad.jp/cloud/objectstorage/api/api-json.html)
 
-公開されている定義ファイルのままではlintでエラーになる箇所やoapi-codegenで扱いにくい箇所があるため手作業で修正しています。
+公開されている定義ファイルのままではoapi-codegenで扱いにくい箇所があるため手作業で修正しています。
 修正は以下のように行っています。
 
 - オリジナルの定義ファイルをダウンロード、`original-swagger.json`として保存
@@ -13,44 +13,8 @@
 `original-swagger.yaml`については生成される対象なため`.gitignore`に登録されています。
 今後オリジナルの定義ファイルが更新された場合は`original-swagger.yaml`と`swagger.yaml`のdiffを取り、適宜`swagger.yaml`へ反映するようにします。
 
-### オリジナルの定義ファイルにおける既知の問題点
-
-- `components.securitySchemes.Account_api_key`でのタイプミス 
-    - 修正前: `schema`
-    - 修正後: `scheme`
-- `components.securitySchemes.Account_api_key.type`でのタイプミス
-    - 修正前: `HTTP`
-    - 修正後: `http`
-- 正規表現パターンの指定誤り:
-  - 修正前:`^[\w\d-_]+$`
-  - 修正後:`^[\w\d_-]+$`
-  :bulb: `-`を指定する時は最初か最後に書く必要がある
-- `example`が`pettern`で指定した正規表現にマッチしない
-  - `components.schemas.Code`: pattern=`^\w+$`, examples=`abc01234@foo@isk01` (patternの誤り)
-    - 修正前:`^\w+$`
-    - 修正後:`^[\w@]+$`
-  - `components.schemas.DisplayName`: pattern=`^\w+$`, examples=`abc012345-` (patternの誤り)
-    - 修正前:`^\w+$`
-    - 修正後:`^.+$`
-    :warning: 入力パターンが不明なため`.`にしているが、API側で制御しているのであれば適切に指定するのが望ましい
-  - `components.schemas.AccessKeyID`: pattern=`^[\w\d\/]{40}$`, examples=`abcdefABCDEF0123456789` (patternの誤り)
-    - 修正前:`^[\w\d\/]{40}$`
-    - 修正後:`^[\w\d\/]{1,40}$`
-    :warning: 数量詞誤りと思われるが、出現パターンが不明なため広く設定している
-  - `components.schemas.SecretAccessKey`: pattern=`^[\w\d\/]{40}$`, examples=`NOTICE: EXISTS ONLY WHEN JUST CREATED` 
-    - 修正前: pattern=`^[\w\d\/]{40}$`, `examples=`NOTICE: EXISTS ONLY WHEN JUST CREATED`
-    - 修正後: pattern=`^[\w\d\/=]{40}$`, `examples=`==NOTICE==EXISTS/ONLY/WHEN/JUST/CREATED=`
-      :warning: パターン不明なため実際の値を数パターンみて判定
-  - `components.schemas.PermissionSecret`: pattern=`^[\w\d\/]{40}$`, examples=`NOTICE: EXISTS ONLY WHEN JUST CREATED`
-    - 修正前: pattern=`^[\w\d\/]{40}$`, `examples=`NOTICE: EXISTS ONLY WHEN JUST CREATED`
-    - 修正後: pattern=`^[\w\d\/=]{40}$`, `examples=`==NOTICE==EXISTS/ONLY/WHEN/JUST/CREATED=`
-      `components.schemas.SecretAccessKey`と同じ
-  - `components.schemas.Session.access_key_secret`: pattern=`^[\w\d\/]{40}$`, examples=`abcdefABCDEF0123456789` (patternの誤り)
-    - 修正前:`^[\w\d\/]{40}$`
-    - 修正後:`^[\w\d\/]{1,40}$`
-      `components.schemas.AccessKeyID`と同じ
-
-### その他の修正点
+### 修正点
 
 - [サーバURLを`https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0`に統一](https://github.com/sacloud/object-storage-api-go/pull/9)
-- [各操作に`operationId`を付与](https://github.com/sacloud/object-storage-api-go/pull/9)
+- 匿名型隣らないように型定義を切り出し
+- requiredの追加

--- a/apis/v1/spec/original-swagger.json
+++ b/apis/v1/spec/original-swagger.json
@@ -3,6 +3,9 @@
   "info": {
     "version": "1.0.0",
     "title": "さくらのオブジェクトストレージ APIドキュメント",
+    "contact": {
+      "name": "SAKURA internet Inc."
+    },
     "license": {
       "name": "Copyright(C) 2021 SAKURA internet Inc. all rights reserved."
     },
@@ -10,11 +13,12 @@
       "url": "logo.svg",
       "altText": "さくらのオブジェクトストレージ：APIドキュメント"
     },
-    "description": "\n---\n\n「さくらのオブジェクトストレージ」が提供するAPIの利用方法とサンプルを公開しております。\n\n# 基本的な使い方\n\n## APIキーの発行\n\nAPIを利用するためには、認証のための「APIキー」が必要です。事前にキーを発行しておきます。\nAPIキーは「ユーザーID」「パスワード」に相当する「トークン」と呼ばれる認証情報で構成されています。\n\n|   項目名   | APIキー発行時の項目名        | このドキュメント内での例             |\n|------------|------------------------------|--------------------------------------|\n| ユーザーID | アクセストークン(UUID)       | 01234567-89ab-cdef-0123-456789abcdef |\n| パスワード | アクセストークンシークレット | SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM |\n\n<div class=\"warning\">\n<b>操作マニュアル</b><br />\n<ul><li><a href=\"https://manual.sakura.ad.jp/cloud/api/apikey.html\">APIキー | さくらのクラウド ドキュメント</a></li></ul>\n</div>\n\n## 入力パラメータ\n\nAPIの入力には送信先URLに対して、いくつかのヘッダーとAPIキーを送信します。\n\n* APIのURLは以下の2つが存在します。※ 各APIの使い分けは後述します。\n  * `https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/fed/v1/(エンドポイント)`\n  * `https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/（サイト名）/v2/(エンドポイント)`\n* 認証方式はHTTP Basic認証です。APIキーのアクセストークンをユーザーID、アクセストークンシークレットをパスワードとして指定します。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     'https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/fed/v1/clusters'\n```\n\n## 出力結果と応答コード（HTTPステータスコード）\n\nAPIからの結果は、「応答コード（HTTPステータスコード）」と、「JSON形式(UTF-8)の結果」として出力されます。\n\n応答コードは、リクエストが成功したのか、失敗したのか大まかな情報を判断することができるもので、例えば失敗したときには、なぜこのような結果になったのかなど、具体的な情報は応答コードと主に返された本文を見ることで把握することができます。\n\n| 結果                                | 応答コード/status   |\n|-------------------------------------|---------------------|\n| 成功（要求を受け付けた）             | 2xx                 |\n| 失敗（要求が受け付けられなかった）  | 4xx, 5xx            |\n\n```\n# 出力結果サンプル（レスポンスヘッダ）\nHTTP/1.1 200 OK\nServer: nginx\nDate: Tue, 16 Nov 2021 12:39:48 GMT\nContent-Type: application/json; charset=UTF-8\nContent-Length: 443\nConnection: keep-alive\nStatus: 200 OK\nPragma: no-cache\nCache-Control: no-cache\nX-Sakura-Proxy-Microtime: 66245\nX-Sakura-Proxy-Decode-Microtime: 62\nX-Sakura-Content-Length: 443\nX-Sakura-Serial: 86ab6c743f72aa5ea6f17e254fd5f803\nX-Content-Type-Options: nosniff\nX-XSS-Protection: 1; mode=block\nX-Frame-Options: DENY\nX-Sakura-Encode-Microtime: 260\nVary: Accept-Encoding\n```\n\n```\n# 出力結果サンプル（レスポンスボディー）\n{\n  \"error\": {\n    \"code\": 404,\n    \"errors\": [\n      {\n        \"domain\": \"fed.objectstorage.sacloud\",\n        \"location\": \"clusters\",\n        \"location_type\": \"path_parameter\",\n        \"message\": \"Cluster was not found\",\n        \"reason\": \"not_found\"\n      }\n    ],\n    \"message\": \"Cluster was not found\",\n    \"trace_id\": \"0f36837633984f3fc8871f515e8efa24\"\n  }\n}\n```\n\n# 利用例\n\n## 1.接続先サイト一覧の取得\n\nさくらのオブジェクトストレージを利用するには、まずバケット作成先となる**サイト**を取得・選択します。\n\nサイト一覧を取得するには、以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     'https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/fed/v1/clusters'\n```\n\n実行結果として、サイトのリストが返却されます。\n\n```\n# 出力結果サンプル\n{\n  \"data\": [\n    {\n      \"api_zone\": [],\n      \"control_panel_url\": \"https://secure.sakura.ad.jp/objectstorage/\",\n      \"dislpay_name_en_us\": \"Ishikari Site #1\",\n      \"dislpay_name_ja\": \"石狩第1サイト\",\n      \"display_name\": \"石狩第1サイト\",\n      \"display_order\": 1,\n      \"endpoint_base\": \"isk01.sakurastorage.jp\",\n      \"id\": \"isk01\",\n      \"s3_endpoint\": \"s3.isk01.sakurastorage.jp\",\n      \"s3_endpoint_for_control_panel\": \"s3.cp.isk01.sakurastorage.jp\",\n      \"storage_zone\": []\n    }\n  ]\n}\n```\n\n得られたサイトID（上記の`id`フィールド）を確認します。これは後続の利用例で使用します。\n\n## 2.サイトアカウントの作成\n\n上記のサイトから利用したいサイトIDを選択し（ここではisk01を選択することにします）、**サイトアカウント**を作成します。\n\nサイトアカウントとは、サイトを利用するための独立したアカウントであり、サイトアカウント作成・削除による料金の発生はございません。\nなお、すでにサイトアカウントを作成済みの場合は、再度サイトアカウントの作成は不要です。\n\nサイトアカウントを作成するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X POST \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/isk01/v2/account\n```\n\nサイトアカウントの作成が完了すると、選択したサイトにて\n\n* バケットの作成・削除\n* アクセスキーの発行・削除\n* パーミッションキーの発行・削除\n\nなどの操作が可能になります。\n\n## 3.バケットの作成・削除\n\n選択したサイトにてサイトアカウントを作成後、**バケット**の作成・削除が可能です。\n\nバケットを作成するには以下のような入力を行います。    \nこの時、選択したサイト（ここではisk01とします）をリクエストボディーに入れ、作成したいバケット名をパスパラメータに入れる必要があります。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X PUT \\\n     -d '{\"cluster_id\": \"isk01\"}' \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/fed/v1/buckets/sample\n```\n\n上記で作成したバケットを削除するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X DELETE \\\n     -d '{\"cluster_id\": \"isk01\"}' \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/fed/v1/buckets/sample\n```\n\n## 4.アクセスキーの発行・削除\n\n選択したサイトにてサイトアカウントを作成後、**アクセスキー**の発行・削除が可能です。\n\nアクセスキーを発行するには以下のような入力を行います。    \n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X POST \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/isk01/v2/account/keys\n```\n\nコマンド結果には以下のフィールドが含まれます。\n\n* `created_at` : 作成日時\n* `id` : アクセスキーID\n* `secret` : シークレットアクセスキー\n\n```\n# 出力結果サンプル\n{\n  \"data\": {\n    \"created_at\": \"2021-11-04T07:42:41.121418479Z\",\n    \"id\": \"XPJK4SC9883N91RHR253\",\n    \"secret\": \"jqRaUo5l+EiEYqP8wos9exbmFfq4/vG8CLPYI2XN\"\n  }\n}\n```\n\n上記で作成したアクセスキーを削除するには以下のような入力を行います。    \nこの時、削除したいアクセスキーIDをパスパラメータに入れる必要があります。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X DELETE \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/isk01/v2/account/keys/XPJK4SC9883N91RHR253\n```\n\n## 5.パーミッション及びパーミッションアクセスキーの発行・削除\n\n選択したサイトにてサイトアカウントを作成後且つバケットが1つ以上ある場合、**パーミッション**の発行・削除が可能です。\n\nパーミッションを作成するには以下のような入力を行います。\nこの時、パーミッション名、パーミッションで制御したいバケットとそれに対する操作をリクエストボディーに入れる必要があります。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X POST \\\n     -d '{\"display_name\": \"sample_permission\", \"bucket_controls\": [{\"bucket_name\": \"sample\", \"can_read\": true, \"can_write\": true}]}' \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/isk01/v2/permissions\n```\n\n作成が完了すると、パーミッションIDが含まれたレスポンスを受け取ります。\n```\n# 出力サンプル\n{\n  \"data\":{\n    \"bucket_controls\":[\n      {\n        \"bucket_name\":\"sample\",\n        \"can_read\":true,\n        \"can_write\":true,\n        \"created_at\":\"2021-11-11T13:36:08.767118492Z\"\n      }\n    ],\n    \"created_at\":\"2021-11-11T13:36:08.690384415Z\",\n    \"display_name\":\"sample_permission\",\n    \"id\":619\n  }\n}\n```\n\nこのパーミッションのアクセスキーを発行するには以下のような入力を行います。\nこの時、パーミッション作成時に発行されたID（ここでは619とします）をパスパラメータに含める必要があります。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X POST \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/isk01/v2/permissions/619/keys\n```\n\nコマンド結果には以下のフィールドが含まれます。\n\n* `created_at` : 作成日時\n* `id` : アクセスキーID\n* `secret` : シークレットアクセスキー\n\n```\n# 出力結果サンプル\n{\n  \"data\": {\n    \"created_at\": \"2021-11-04T07:42:41.121418479Z\",\n    \"id\": \"XPJK4SC9883N91RHR253\",\n    \"secret\": \"jqRaUo5l+EiEYqP8wos9exbmFfq4/vG8CLPYI2XN\"\n  }\n}\n```\n\nパーミッションアクセスキーを削除するには以下のような入力を行います。\nこの時、パーミッションアクセスキー発行時に出力されたIDをパスパラメータに含める必要があります。\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X DELETE \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/isk01/v2/permissions/619/keys/XPJK4SC9883N91RHR253\n```\n\nパーミッションを削除するには以下のような入力を行います。\nこの時、パーミッション作成時に発行されたID（ここでは619とします）をパスパラメータに含める必要があります。\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X DELETE \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/isk01/v2/permissions/619\n```\n----\n\n# Authentication\n\n<!-- ReDoc-Inject: <security-definitions> -->"
+    "description": "\n---\n\n「さくらのオブジェクトストレージ」が提供するAPIの利用方法とサンプルを公開しております。\n\n# 基本的な使い方\n\n## APIキーの発行\n\nAPIを利用するためには、認証のための「APIキー」が必要です。事前にキーを発行しておきます。\nAPIキーは「ユーザーID」「パスワード」に相当する「トークン」と呼ばれる認証情報で構成されています。\n\n|   項目名   | APIキー発行時の項目名        | このドキュメント内での例             |\n|------------|------------------------------|--------------------------------------|\n| ユーザーID | アクセストークン(UUID)       | 01234567-89ab-cdef-0123-456789abcdef |\n| パスワード | アクセストークンシークレット | SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM |\n\n<div class=\"warning\">\n<b>操作マニュアル</b><br />\n<ul><li><a href=\"https://manual.sakura.ad.jp/cloud/api/apikey.html\">APIキー | さくらのクラウド ドキュメント</a></li></ul>\n</div>\n\n## 入力パラメータ\n\nAPIの入力には送信先URLに対して、いくつかのヘッダーとAPIキーを送信します。\n\n* APIのURLは以下の2つが存在します。※ 各APIの使い分けは後述します。\n  * `https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/fed/v1/(エンドポイント)`\n  * `https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/（サイト名）/v2/(エンドポイント)`\n* 認証方式はHTTP Basic認証です。APIキーのアクセストークンをユーザーID、アクセストークンシークレットをパスワードとして指定します。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     'https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/fed/v1/clusters'\n```\n\n## 出力結果と応答コード（HTTPステータスコード）\n\nAPIからの結果は、「応答コード（HTTPステータスコード）」と、「JSON形式(UTF-8)の結果」として出力されます。\n\n応答コードは、リクエストが成功したのか、失敗したのか大まかな情報を判断することができるもので、例えば失敗したときには、なぜこのような結果になったのかなど、具体的な情報は応答コードと主に返された本文を見ることで把握することができます。\n\n| 結果                                | 応答コード/status   |\n|-------------------------------------|---------------------|\n| 成功（要求を受け付けた）             | 2xx                 |\n| 失敗（要求が受け付けられなかった）  | 4xx, 5xx            |\n\n```\n# 出力結果サンプル（レスポンスヘッダ）\nHTTP/1.1 200 OK\nServer: nginx\nDate: Tue, 16 Nov 2021 12:39:48 GMT\nContent-Type: application/json; charset=UTF-8\nContent-Length: 443\nConnection: keep-alive\nStatus: 200 OK\nPragma: no-cache\nCache-Control: no-cache\nX-Sakura-Proxy-Microtime: 66245\nX-Sakura-Proxy-Decode-Microtime: 62\nX-Sakura-Content-Length: 443\nX-Sakura-Serial: 86ab6c743f72aa5ea6f17e254fd5f803\nX-Content-Type-Options: nosniff\nX-XSS-Protection: 1; mode=block\nX-Frame-Options: DENY\nX-Sakura-Encode-Microtime: 260\nVary: Accept-Encoding\n```\n\n```\n# 出力結果サンプル（レスポンスボディー）\n{\n  \"error\": {\n    \"code\": 404,\n    \"errors\": [\n      {\n        \"domain\": \"fed.objectstorage.sacloud\",\n        \"location\": \"clusters\",\n        \"location_type\": \"path_parameter\",\n        \"message\": \"Cluster was not found\",\n        \"reason\": \"not_found\"\n      }\n    ],\n    \"message\": \"Cluster was not found\",\n    \"trace_id\": \"0f36837633984f3fc8871f515e8efa24\"\n  }\n}\n```\n\n# 利用例\n\n## 1.接続先サイト一覧の取得\n\nさくらのオブジェクトストレージを利用するには、まずバケット作成先となる**サイト**を取得・選択します。\n\nサイト一覧を取得するには、以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     'https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/fed/v1/clusters'\n```\n\n実行結果として、サイトのリストが返却されます。\n\n```\n# 出力結果サンプル\n{\n  \"data\": [\n    {\n      \"api_zone\": [],\n      \"control_panel_url\": \"https://secure.sakura.ad.jp/objectstorage/\",\n      \"display_name_en_us\": \"Ishikari Site #1\",\n      \"display_name_ja\": \"石狩第1サイト\",\n      \"display_name\": \"石狩第1サイト\",\n      \"display_order\": 1,\n      \"endpoint_base\": \"isk01.sakurastorage.jp\",\n      \"id\": \"isk01\",\n      \"s3_endpoint\": \"s3.isk01.sakurastorage.jp\",\n      \"s3_endpoint_for_control_panel\": \"s3.cp.isk01.sakurastorage.jp\",\n      \"storage_zone\": []\n    }\n  ]\n}\n```\n\n得られたサイトID（上記の`id`フィールド）を確認します。これは後続の利用例で使用します。\n\n## 2.サイトアカウントの作成\n\n上記のサイトから利用したいサイトIDを選択し（ここではisk01を選択することにします）、**サイトアカウント**を作成します。\n\nサイトアカウントとは、サイトを利用するための独立したアカウントであり、サイトアカウント作成・削除による料金の発生はございません。\nなお、すでにサイトアカウントを作成済みの場合は、再度サイトアカウントの作成は不要です。\n\nサイトアカウントを作成するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X POST \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/isk01/v2/account\n```\n\nサイトアカウントの作成が完了すると、選択したサイトにて\n\n* バケットの作成・削除\n* アクセスキーの発行・削除\n* パーミッションキーの発行・削除\n\nなどの操作が可能になります。\n\n## 3.バケットの作成・削除\n\n選択したサイトにてサイトアカウントを作成後、**バケット**の作成・削除が可能です。\n\nバケットを作成するには以下のような入力を行います。    \nこの時、選択したサイト（ここではisk01とします）をリクエストボディーに入れ、作成したいバケット名をパスパラメータに入れる必要があります。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X PUT \\\n     -d '{\"cluster_id\": \"isk01\"}' \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/fed/v1/buckets/sample\n```\n\n上記で作成したバケットを削除するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X DELETE \\\n     -d '{\"cluster_id\": \"isk01\"}' \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/fed/v1/buckets/sample\n```\n\n## 4.アクセスキーの発行・削除\n\n選択したサイトにてサイトアカウントを作成後、**アクセスキー**の発行・削除が可能です。\n\nアクセスキーを発行するには以下のような入力を行います。    \n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X POST \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/isk01/v2/account/keys\n```\n\nコマンド結果には以下のフィールドが含まれます。\n\n* `created_at` : 作成日時\n* `id` : アクセスキーID\n* `secret` : シークレットアクセスキー\n\n```\n# 出力結果サンプル\n{\n  \"data\": {\n    \"created_at\": \"2021-11-04T07:42:41.121418479Z\",\n    \"id\": \"XPJK4SC9883N91RHR253\",\n    \"secret\": \"jqRaUo5l+EiEYqP8wos9exbmFfq4/vG8CLPYI2XN\"\n  }\n}\n```\n\n上記で作成したアクセスキーを削除するには以下のような入力を行います。    \nこの時、削除したいアクセスキーIDをパスパラメータに入れる必要があります。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X DELETE \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/isk01/v2/account/keys/XPJK4SC9883N91RHR253\n```\n\n## 5.パーミッション及びパーミッションアクセスキーの発行・削除\n\n選択したサイトにてサイトアカウントを作成後且つバケットが1つ以上ある場合、**パーミッション**の発行・削除が可能です。\n\nパーミッションを作成するには以下のような入力を行います。\nこの時、パーミッション名、パーミッションで制御したいバケットとそれに対する操作をリクエストボディーに入れる必要があります。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X POST \\\n     -d '{\"display_name\": \"sample_permission\", \"bucket_controls\": [{\"bucket_name\": \"sample\", \"can_read\": true, \"can_write\": true}]}' \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/isk01/v2/permissions\n```\n\n作成が完了すると、パーミッションIDが含まれたレスポンスを受け取ります。\n```\n# 出力サンプル\n{\n  \"data\": {\n    \"bucket_controls\": [\n      {\n        \"bucket_name\":\"sample\",\n        \"can_read\":true,\n        \"can_write\":true,\n        \"created_at\":\"2021-11-11T13:36:08.767118492Z\"\n      }\n    ],\n    \"created_at\":\"2021-11-11T13:36:08.690384415Z\",\n    \"display_name\":\"sample_permission\",\n    \"id\":619\n  }\n}\n```\n\nこのパーミッションのアクセスキーを発行するには以下のような入力を行います。\nこの時、パーミッション作成時に発行されたID（ここでは619とします）をパスパラメータに含める必要があります。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X POST \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/isk01/v2/permissions/619/keys\n```\n\nコマンド結果には以下のフィールドが含まれます。\n\n* `created_at` : 作成日時\n* `id` : アクセスキーID\n* `secret` : シークレットアクセスキー\n\n```\n# 出力結果サンプル\n{\n  \"data\": {\n    \"created_at\": \"2021-11-04T07:42:41.121418479Z\",\n    \"id\": \"XPJK4SC9883N91RHR253\",\n    \"secret\": \"jqRaUo5l+EiEYqP8wos9exbmFfq4/vG8CLPYI2XN\"\n  }\n}\n```\n\nパーミッションアクセスキーを削除するには以下のような入力を行います。\nこの時、パーミッションアクセスキー発行時に出力されたIDをパスパラメータに含める必要があります。\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X DELETE \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/isk01/v2/permissions/619/keys/XPJK4SC9883N91RHR253\n```\n\nパーミッションを削除するには以下のような入力を行います。\nこの時、パーミッション作成時に発行されたID（ここでは619とします）をパスパラメータに含める必要があります。\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X DELETE \\\n     https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0/isk01/v2/permissions/619\n```\n----\n\n# Authentication\n\n<!-- ReDoc-Inject: <security-definitions> -->"
   },
   "paths": {
     "/clusters": {
       "get": {
+        "operationId": "getClusters",
         "tags": [
           "サイト"
         ],
@@ -51,6 +55,7 @@
     },
     "/clusters/{id}": {
       "get": {
+        "operationId": "getCluster",
         "tags": [
           "サイト"
         ],
@@ -108,6 +113,7 @@
     },
     "/buckets/{name}": {
       "put": {
+        "operationId": "createBucket",
         "tags": [
           "バケット"
         ],
@@ -184,6 +190,7 @@
         }
       },
       "delete": {
+        "operationId": "deleteBucket",
         "tags": [
           "バケット"
         ],
@@ -205,27 +212,9 @@
             "description": "バケット名"
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/handler.PutBucketReqBody"
-              }
-            }
-          },
-          "description": "作成したいバケット情報",
-          "required": true
-        },
         "responses": {
-          "201": {
-            "description": "バケット作成に成功しました",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/handler.putBucketRes"
-                }
-              }
-            }
+          "204": {
+            "description": "バケット削除に成功しました"
           },
           "400": {
             "description": "バケット名が不正です",
@@ -252,6 +241,7 @@
     },
     "/account": {
       "get": {
+        "operationId": "getAccount",
         "tags": [
           "サイトアカウント"
         ],
@@ -306,6 +296,7 @@
         }
       },
       "post": {
+        "operationId": "createAccount",
         "tags": [
           "サイトアカウント"
         ],
@@ -370,6 +361,7 @@
         }
       },
       "delete": {
+        "operationId": "deleteAccount",
         "tags": [
           "サイトアカウント"
         ],
@@ -419,6 +411,7 @@
     },
     "/account/keys": {
       "get": {
+        "operationId": "getAccountKeys",
         "tags": [
           "サイトアカウント"
         ],
@@ -473,6 +466,7 @@
         }
       },
       "post": {
+        "operationId": "createAccountKey",
         "tags": [
           "サイトアカウント"
         ],
@@ -539,6 +533,7 @@
     },
     "/account/keys/{id}": {
       "get": {
+        "operationId": "getAccountKey",
         "tags": [
           "サイトアカウント"
         ],
@@ -604,6 +599,7 @@
         }
       },
       "delete": {
+        "operationId": "deleteAccountKey",
         "tags": [
           "サイトアカウント"
         ],
@@ -654,6 +650,7 @@
     },
     "/permissions": {
       "get": {
+        "operationId": "getPermissions",
         "tags": [
           "パーミッション"
         ],
@@ -670,7 +667,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Permission"
+                  "$ref": "#/components/schemas/Permissions"
                 }
               }
             }
@@ -698,6 +695,7 @@
         }
       },
       "post": {
+        "operationId": "createPermission",
         "tags": [
           "パーミッション"
         ],
@@ -776,6 +774,7 @@
     },
     "/permissions/{id}": {
       "get": {
+        "operationId": "getPermission",
         "tags": [
           "パーミッション"
         ],
@@ -841,6 +840,7 @@
         }
       },
       "put": {
+        "operationId": "updatePermission",
         "tags": [
           "パーミッション"
         ],
@@ -927,6 +927,7 @@
         }
       },
       "delete": {
+        "operationId": "deletePermission",
         "tags": [
           "パーミッション"
         ],
@@ -977,6 +978,7 @@
     },
     "/permissions/{id}/keys": {
       "get": {
+        "operationId": "getPermissionKeys",
         "tags": [
           "パーミッション"
         ],
@@ -1004,7 +1006,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PermissionKey"
+                  "$ref": "#/components/schemas/PermissionKeys"
                 }
               }
             }
@@ -1042,6 +1044,7 @@
         }
       },
       "post": {
+        "operationId": "createPermissionKey",
         "tags": [
           "パーミッション"
         ],
@@ -1119,6 +1122,7 @@
     },
     "/permissions/{id}/keys/{key_id}": {
       "get": {
+        "operationId": "getPermissionKey",
         "tags": [
           "パーミッション"
         ],
@@ -1193,6 +1197,7 @@
         }
       },
       "delete": {
+        "operationId": "deletePermissionKey",
         "tags": [
           "パーミッション"
         ],
@@ -1262,6 +1267,7 @@
     },
     "/status": {
       "get": {
+        "operationId": "getStatus",
         "tags": [
           "ステータス"
         ],
@@ -1312,14 +1318,14 @@
       "url": "/objectstorage/fed/api/v1"
     },
     {
-      "url": "/objectstorage/1.0/{site_name}/v2/"
+      "url": "/objectstorage/1.0/{site_name}/v2"
     }
   ],
   "components": {
     "securitySchemes": {
-      "Account_api_key": {
-        "type": "HTTP",
-        "schema": "basic",
+      "BasicAuth": {
+        "type": "http",
+        "scheme": "basic",
         "description": "[クラウドコントロールパネル](https://secure.sakura.ad.jp/cloud/)で発行したAPIキーを利用します。\n\n `アクセストークン(UUID)` を「ユーザーID」、`アクセストークンシークレット` を「パスワード」として指定します。"
       }
     },
@@ -1392,12 +1398,12 @@
             "type": "string",
             "example": "secure.sakura.ad.jp/objectstorage/isk01"
           },
-          "dislpay_name_en_us": {
+          "display_name_en_us": {
             "description": "Display Name (en-us)",
             "type": "string",
             "example": "Ishikari Cluster #1"
           },
-          "dislpay_name_ja": {
+          "display_name_ja": {
             "description": "Display Name (ja)",
             "type": "string",
             "example": "石狩第1サイト"
@@ -1454,66 +1460,6 @@
           }
         }
       },
-      "model.HTTPErr": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "$ref": "#/components/schemas/model.HTTPErrDoc"
-          }
-        }
-      },
-      "model.HTTPErrDoc": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "integer",
-            "example": 429
-          },
-          "errors": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/model.InnerErr"
-            }
-          },
-          "message": {
-            "type": "string",
-            "example": "Rate Limit Exceeded"
-          },
-          "trace_id": {
-            "description": "X-Sakura-Internal-Serial-ID",
-            "type": "string",
-            "example": "0f36837633984f3fc8871f515e8efa24"
-          }
-        }
-      },
-      "model.InnerErr": {
-        "type": "object",
-        "properties": {
-          "domain": {
-            "description": "global, usage,...",
-            "type": "string",
-            "example": "usage"
-          },
-          "location": {
-            "description": "Authorization, {paramName},...",
-            "type": "string"
-          },
-          "location_type": {
-            "description": "header, parameter,...",
-            "type": "string"
-          },
-          "message": {
-            "description": "{description}",
-            "type": "string",
-            "example": "Rate Limit Exceeded"
-          },
-          "reason": {
-            "description": "invalidParameter, required,...",
-            "type": "string",
-            "example": "rateLimitExceeded"
-          }
-        }
-      },
       "PermissionID": {
         "description": "Permission ID",
         "type": "integer",
@@ -1529,7 +1475,7 @@
       "Code": {
         "description": "Code",
         "type": "string",
-        "pattern": "^\\w+$",
+        "pattern": "^[\\w@]+$",
         "example": "abc01234@foo@isk01"
       },
       "CreatedAt": {
@@ -1557,20 +1503,20 @@
       "DisplayName": {
         "description": "Display name",
         "type": "string",
-        "pattern": "^\\w+$",
+        "pattern": "^.+$",
         "example": "abc012345-"
       },
       "AccessKeyID": {
         "description": "Access key ID",
         "type": "string",
-        "pattern": "^[\\w\\d\\/]{40}$",
+        "pattern": "^[\\w\\d\\/]{1,40}$",
         "example": "abcdefABCDEF0123456789"
       },
       "SecretAccessKey": {
         "description": "Secret Access key",
         "type": "string",
-        "pattern": "^[\\w\\d\\/]{40}$",
-        "example": "NOTICE: EXISTS ONLY WHEN JUST CREATED"
+        "pattern": "^[\\w\\d\\/+=]{1,40}$",
+        "example": "/NOTICE==EXISTS+ONLY+WHEN+JUST+CREATED/"
       },
       "accountKeys": {
         "description": "Root user access keys",
@@ -1665,14 +1611,8 @@
       "PermissionSecret": {
         "description": "Permission secret key",
         "type": "string",
-        "pattern": "^[\\w\\d\\/]{40}$",
-        "example": "NOTICE: EXISTS ONLY WHEN JUST CREATED"
-      },
-      "BucketGrantFullControl": {
-        "description": "Bucket Grant Full Control",
-        "type": "string",
-        "pattern": "^[\\w\\d-_]+$",
-        "example": "grantfullControl"
+        "pattern": "^[\\w\\d\\/+=]{1,40}$",
+        "example": "/NOTICE==EXISTS+ONLY+WHEN+JUST+CREATED/"
       },
       "Account": {
         "description": "Account info",
@@ -1707,155 +1647,7 @@
           }
         }
       },
-      "BucketGrantRead": {
-        "description": "Bucket Grant Read",
-        "type": "boolean",
-        "example": true
-      },
-      "BucketGrantReadAcp": {
-        "description": "Bucket Grant Read ACP",
-        "type": "string",
-        "example": "Bucket Grant Read ACP"
-      },
-      "BucketGrantWrite": {
-        "description": "Bcuket Grant Write",
-        "type": "boolean",
-        "example": true
-      },
-      "BucketGrantWriteAcp": {
-        "description": "Bucket Grant Write ACP",
-        "type": "string",
-        "example": "Bucket Grant Write ACP"
-      },
-      "BucketBody": {
-        "description": "Request body for bucket",
-        "type": "object",
-        "properties": {
-          "acl": {
-            "type": "string",
-            "example": "{\n  \"Owner\": {\n    \"DisplayName\": \"123456789012\",\n    \"ID\": \"abcdefABCDEF0123456789\"\n  },\n  \"Grants\": [\n    {\n      \"Grantee\": {\n        \"DisplayName\": \"113100030424\",\n        \"ID\": \"abcedefABCDEF0123456789\",\n        \"Type\": \"CanonicalUser\"\n      },\n      \"Permission\": \"FULL_CONTROL\"\n    }\n  ]\n}\n"
-          },
-          "grant_full_control": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BucketGrantFullControl"
-              }
-            ]
-          },
-          "grant_read": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BucketGrantRead"
-              }
-            ]
-          },
-          "grnat_read_acp": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BucketGrantReadAcp"
-              }
-            ]
-          },
-          "grant_write": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BucketGrantWrite"
-              }
-            ]
-          },
-          "grant_write_acp": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BucketGrantWriteAcp"
-              }
-            ]
-          }
-        }
-      },
-      "Bucket": {
-        "description": "Bucket",
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/BucketName"
-                  }
-                ]
-              },
-              "resource_id": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/ResourceID"
-                  }
-                ]
-              }
-            }
-          }
-        }
-      },
-      "BucketForGetACL": {
-        "description": "Bucket",
-        "type": "object",
-        "properties": {
-          "data": {
-            "description": "data type",
-            "type": "object",
-            "properties": {
-              "owner": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "example": "123456789012"
-                  },
-                  "display_name": {
-                    "type": "string",
-                    "example": "display_name"
-                  }
-                }
-              },
-              "grants": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "grantee": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "example": "abcedefABCDEF0123456789"
-                        },
-                        "display_name": {
-                          "type": "string",
-                          "example": "113100030424"
-                        },
-                        "type": {
-                          "type": "string",
-                          "example": "CanonicalUser"
-                        },
-                        "uri": {
-                          "type": "string",
-                          "example": "uri"
-                        }
-                      }
-                    },
-                    "permission": {
-                      "type": "string",
-                      "example": "permission"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "Permission": {
+      "Permissions": {
         "description": "Permission",
         "type": "object",
         "properties": {
@@ -1898,6 +1690,46 @@
           }
         }
       },
+      "Permission": {
+        "description": "Permission",
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "data type",
+            "type": "object",
+            "properties": {
+              "id": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PermissionID"
+                  }
+                ]
+              },
+              "display_name": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DisplayName"
+                  }
+                ]
+              },
+              "bucket_controls": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BucketControls"
+                  }
+                ]
+              },
+              "created_at": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/CreatedAt"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
       "PermissionBucketControlsBody": {
         "description": "Request body for bucket controls for Permission",
         "type": "object",
@@ -1915,6 +1747,42 @@
                 "$ref": "#/components/schemas/BucketControls"
               }
             ]
+          }
+        }
+      },
+      "PermissionKeys": {
+        "description": "Permission Key",
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "data type",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PermissionID"
+                    }
+                  ]
+                },
+                "secret": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PermissionSecret"
+                    }
+                  ]
+                },
+                "created_at": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/CreatedAt"
+                    }
+                  ]
+                }
+              }
+            }
           }
         }
       },
@@ -1948,61 +1816,6 @@
                 ]
               }
             }
-          }
-        }
-      },
-      "Session": {
-        "description": "Session",
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object",
-            "properties": {
-              "access_key_id": {
-                "type": "string",
-                "example": "abcdefABCDEF0123456789"
-              },
-              "access_key_secret": {
-                "type": "string",
-                "pattern": "^[\\w\\d\\/]{40}$",
-                "example": "abcdefABCDEF0123456789"
-              },
-              "user": {
-                "type": "string",
-                "example": "user_name"
-              },
-              "created_at": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatedAt"
-                  }
-                ]
-              },
-              "expired_at": {
-                "type": "string",
-                "format": "date-time",
-                "example": "2021-01-11T01:11:23.123456+09:00"
-              }
-            }
-          }
-        }
-      },
-      "SessionBody": {
-        "description": "Session body",
-        "type": "object",
-        "properties": {
-          "expires_at": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2020-01-11T01:11:23.123456+09:00"
-          },
-          "token": {
-            "type": "string",
-            "example": "abcdefABCDEF0123456789"
-          },
-          "user": {
-            "type": "string",
-            "example": "user_name"
           }
         }
       },
@@ -2379,5 +2192,27 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "サイト",
+      "description": "サイトに関する情報"
+    },
+    {
+      "name": "バケット",
+      "description": "バケットに関する情報"
+    },
+    {
+      "name": "サイトアカウント",
+      "description": "サイトアカウントに関する情報"
+    },
+    {
+      "name": "パーミッション",
+      "description": "パーミッションに関する情報"
+    },
+    {
+      "name": "ステータス",
+      "description": "ステータスに関する情報"
+    }
+  ]
 }

--- a/apis/v1/spec/swagger.yaml
+++ b/apis/v1/spec/swagger.yaml
@@ -2,6 +2,8 @@ openapi: 3.0.0
 info:
   version: 1.0.0
   title: さくらのオブジェクトストレージ APIドキュメント
+  contact:
+    name: SAKURA internet Inc.
   license:
     name: Copyright(C) 2021 SAKURA internet Inc. all rights reserved.
   x-logo:
@@ -121,8 +123,8 @@ info:
         {
           "api_zone": [],
           "control_panel_url": "https://secure.sakura.ad.jp/objectstorage/",
-          "dislpay_name_en_us": "Ishikari Site #1",
-          "dislpay_name_ja": "石狩第1サイト",
+          "display_name_en_us": "Ishikari Site #1",
+          "display_name_ja": "石狩第1サイト",
           "display_name": "石狩第1サイト",
           "display_order": 1,
           "endpoint_base": "isk01.sakurastorage.jp",
@@ -245,8 +247,8 @@ info:
     ```
     # 出力サンプル
     {
-      "data":{
-        "bucket_controls":[
+      "data": {
+        "bucket_controls": [
           {
             "bucket_name":"sample",
             "can_read":true,
@@ -313,7 +315,7 @@ info:
 paths:
   /fed/v1/clusters:
     get:
-      operationId: "ListClusters"
+      operationId: getClusters
       tags:
         - サイト
       summary: サイト一覧の取得
@@ -339,7 +341,7 @@ paths:
                 $ref: '#/components/schemas/Error401'
   '/fed/v1/clusters/{site_id}':
     get:
-      operationId: "ReadCluster"
+      operationId: getCluster
       tags:
         - サイト
       summary: サイトの取得
@@ -378,7 +380,7 @@ paths:
                 $ref: '#/components/schemas/Error404'
   '/fed/v1/buckets/{bucket_name}':
     put:
-      operationId: "CreateBucket"
+      operationId: createBucket
       tags:
         - バケット
       summary: バケットの作成
@@ -429,7 +431,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error409'
     delete:
-      operationId: "DeleteBucket"
+      operationId: deleteBucket
       tags:
         - バケット
       servers:
@@ -473,7 +475,7 @@ paths:
                 $ref: '#/components/schemas/Error409'
   '/{site_id}/v2/account':
     get:
-      operationId: "ReadSiteAccount"
+      operationId: getAccount
       tags:
         - サイトアカウント
       summary: サイトアカウントの取得
@@ -519,7 +521,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorDefault'
     post:
-      operationId: "CreateSiteAccount"
+      operationId: createAccount
       tags:
         - サイトアカウント
       summary: サイトアカウントの作成
@@ -571,7 +573,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorDefault'
     delete:
-      operationId: "DeleteSiteAccount"
+      operationId: deleteAccount
       tags:
         - サイトアカウント
       summary: サイトアカウントの削除
@@ -608,7 +610,7 @@ paths:
                 $ref: '#/components/schemas/Error409'
   '/{site_id}/v2/account/keys':
     get:
-      operationId: "ListAccountAccessKeys"
+      operationId: getAccountKeys
       tags:
         - サイトアカウント
       summary: サイトアカウントのアクセスキーの取得
@@ -654,7 +656,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorDefault'
     post:
-      operationId: "CreateAccountAccessKey"
+      operationId: createAccountKey
       tags:
         - サイトアカウント
       servers:
@@ -709,7 +711,7 @@ paths:
                 $ref: '#/components/schemas/ErrorDefault'
   '/{site_id}/v2/account/keys/{account_key_id}':
     get:
-      operationId: "ReadAccountAccessKey"
+      operationId: getAccountKey
       tags:
         - サイトアカウント
       summary: サイトアカウントのアクセスキーの取得
@@ -761,7 +763,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorDefault'
     delete:
-      operationId: "DeleteAccountAccessKey"
+      operationId: deleteAccountKey
       tags:
         - サイトアカウント
       summary: サイトアカウントのアクセスキーの削除
@@ -798,7 +800,7 @@ paths:
                 $ref: '#/components/schemas/Error401'
   '/{site_id}/v2/permissions':
     get:
-      operationId: "ListPermissions"
+      operationId: getPermissions
       tags:
         - パーミッション
       summary: パーミッション一覧の取得
@@ -838,7 +840,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorDefault'
     post:
-      operationId: "CreatePermission"
+      operationId: createPermission
       tags:
         - パーミッション
       summary: パーミッションの作成
@@ -898,7 +900,7 @@ paths:
                 $ref: '#/components/schemas/ErrorDefault'
   '/{site_id}/v2/permissions/{permission_id}':
     get:
-      operationId: "ReadPermission"
+      operationId: getPermission
       tags:
         - パーミッション
       summary: パーミッションの取得
@@ -950,7 +952,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorDefault'
     put:
-      operationId: "UpdatePermission"
+      operationId: updatePermission
       tags:
         - パーミッション
       summary: パーミッションの更新
@@ -1071,7 +1073,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorDefault'
     delete:
-      operationId: "DeletePermission"
+      operationId: deletePermission
       tags:
         - パーミッション
       summary: パーミッションの削除
@@ -1108,7 +1110,7 @@ paths:
                 $ref: '#/components/schemas/Error401'
   '/{site_id}/v2/permissions/{permission_id}/keys':
     get:
-      operationId: "ListPermissionAccessKeys"
+      operationId: getPermissionKeys
       tags:
         - パーミッション
       summary: パーミッションが保有するアクセスキー一覧の取得
@@ -1160,7 +1162,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorDefault'
     post:
-      operationId: "CreatePermissionAccessKey"
+      operationId: createPermissionKey
       tags:
         - パーミッション
       summary: パーミッションのアクセスキーの発行
@@ -1219,7 +1221,7 @@ paths:
                 $ref: '#/components/schemas/ErrorDefault'
   '/{site_id}/v2/permissions/{permission_id}/keys/{permission_key_id}':
     get:
-      operationId: "ReadPermissionAccessKey"
+      operationId: getPermissionKey
       tags:
         - パーミッション
       summary: パーミッションが保有するアクセスキーの取得
@@ -1277,7 +1279,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorDefault'
     delete:
-      operationId: "DeletePermissionAccessKey"
+      operationId: deletePermissionKey
       tags:
         - パーミッション
       summary: パーミッションが保有するアクセスキーの削除
@@ -1326,7 +1328,7 @@ paths:
                 $ref: '#/components/schemas/Error404'
   '/{site_id}/v2/status':
     get:
-      operationId: "ReadSiteStatus"
+      operationId: getStatus
       tags:
         - ステータス
       summary: サイトのステータスの取得
@@ -1369,7 +1371,7 @@ servers:
   - url: 'https://secure.sakura.ad.jp/cloud/zone/is1a/api/objectstorage/1.0'
 components:
   securitySchemes:
-    Account_api_key:
+    BasicAuth:
       type: http
       scheme: basic
       description: |-
@@ -1514,11 +1516,11 @@ components:
           description: URL of Control Panel
           type: string
           example: secure.sakura.ad.jp/objectstorage/isk01
-        dislpay_name_en_us:
+        display_name_en_us:
           description: Display Name (en-us)
           type: string
           example: 'Ishikari Cluster #1'
-        dislpay_name_ja:
+        display_name_ja:
           description: Display Name (ja)
           type: string
           example: 石狩第1サイト
@@ -1564,8 +1566,8 @@ components:
       required:
         - api_zone
         - control_panel_url
-        - dislpay_name_en_us
-        - dislpay_name_ja
+        - display_name_en_us
+        - display_name_ja
         - display_name
         - display_order
         - endpoint_base
@@ -1575,49 +1577,6 @@ components:
         - s3_endpoint
         - s3_endpoint_for_control_panel
         - storage_zone
-    #    model.HTTPErr:
-#      type: object
-#      properties:
-#        error:
-#          $ref: '#/components/schemas/model.HTTPErrDoc'
-#    model.HTTPErrDoc:
-#      type: object
-#      properties:
-#        code:
-#          type: integer
-#          example: 429
-#        errors:
-#          type: array
-#          items:
-#            $ref: '#/components/schemas/model.InnerErr'
-#        message:
-#          type: string
-#          example: Rate Limit Exceeded
-#        trace_id:
-#          description: X-Sakura-Internal-Serial-ID
-#          type: string
-#          example: 0f36837633984f3fc8871f515e8efa24
-#    model.InnerErr:
-#      type: object
-#      properties:
-#        domain:
-#          description: 'global, usage,...'
-#          type: string
-#          example: usage
-#        location:
-#          description: 'Authorization, {paramName},...'
-#          type: string
-#        location_type:
-#          description: 'header, parameter,...'
-#          type: string
-#        message:
-#          description: '{description}'
-#          type: string
-#          example: Rate Limit Exceeded
-#        reason:
-#          description: 'invalidParameter, required,...'
-#          type: string
-#          example: rateLimitExceeded
     PermissionID:
       description: Permission ID
       type: integer
@@ -1664,8 +1623,8 @@ components:
     SecretAccessKey:
       description: Secret Access key
       type: string
-      pattern: '^[\w\d\/=]{40}$'
-      example: '==NOTICE==EXISTS/ONLY/WHEN/JUST/CREATED='
+      pattern: '^[\w\d\/+=]{1,40}$'
+      example: /NOTICE==EXISTS+ONLY+WHEN+JUST+CREATED/
     AccountKey:
       description: Root user access key
       type: object
@@ -1710,13 +1669,8 @@ components:
     PermissionSecret:
       description: Permission secret key
       type: string
-      pattern: '^[\w\d\/=]{40}$'
-      example: '==NOTICE==EXISTS/ONLY/WHEN/JUST/CREATED='
-#    BucketGrantFullControl:
-#      description: Bucket Grant Full Control
-#      type: string
-#      pattern: '^[\w\d_-]+$'
-#      example: grantfullControl
+      pattern: '^[\w\d\/+=]{1,40}$'
+      example: /NOTICE==EXISTS+ONLY+WHEN+JUST+CREATED/
 
     # Note: ResponseBody+Accountに分離させた
     Account:
@@ -1733,114 +1687,6 @@ components:
         - resource_id
         - code
         - created_at
-
-#    BucketGrantRead:
-#      description: Bucket Grant Read
-#      type: boolean
-#      example: true
-#    BucketGrantReadAcp:
-#      description: Bucket Grant Read ACP
-#      type: string
-#      example: Bucket Grant Read ACP
-#    BucketGrantWrite:
-#      description: Bcuket Grant Write
-#      type: boolean
-#      example: true
-#    BucketGrantWriteAcp:
-#      description: Bucket Grant Write ACP
-#      type: string
-#      example: Bucket Grant Write ACP
-#    BucketBody:
-#      description: Request body for bucket
-#      type: object
-#      properties:
-#        acl:
-#          type: string
-#          example: |
-#            {
-#              "Owner": {
-#                "DisplayName": "123456789012",
-#                "ID": "abcdefABCDEF0123456789"
-#              },
-#              "Grants": [
-#                {
-#                  "Grantee": {
-#                    "DisplayName": "113100030424",
-#                    "ID": "abcedefABCDEF0123456789",
-#                    "Type": "CanonicalUser"
-#                  },
-#                  "Permission": "FULL_CONTROL"
-#                }
-#              ]
-#            }
-#        grant_full_control:
-#          allOf:
-#            - $ref: '#/components/schemas/BucketGrantFullControl'
-#        grant_read:
-#          allOf:
-#            - $ref: '#/components/schemas/BucketGrantRead'
-#        grnat_read_acp:
-#          allOf:
-#            - $ref: '#/components/schemas/BucketGrantReadAcp'
-#        grant_write:
-#          allOf:
-#            - $ref: '#/components/schemas/BucketGrantWrite'
-#        grant_write_acp:
-#          allOf:
-#            - $ref: '#/components/schemas/BucketGrantWriteAcp'
-#    Bucket:
-#      description: Bucket
-#      type: object
-#      properties:
-#        data:
-#          type: object
-#          properties:
-#            name:
-#              allOf:
-#                - $ref: '#/components/schemas/BucketName'
-#            resource_id:
-#              allOf:
-#                - $ref: '#/components/schemas/ResourceID'
-#    BucketForGetACL:
-#      description: Bucket
-#      type: object
-#      properties:
-#        data:
-#          description: data type
-#          type: object
-#          properties:
-#            owner:
-#              type: object
-#              properties:
-#                id:
-#                  type: string
-#                  example: '123456789012'
-#                display_name:
-#                  type: string
-#                  example: display_name
-#            grants:
-#              type: array
-#              items:
-#                type: object
-#                properties:
-#                  grantee:
-#                    type: object
-#                    properties:
-#                      id:
-#                        type: string
-#                        example: abcedefABCDEF0123456789
-#                      display_name:
-#                        type: string
-#                        example: '113100030424'
-#                      type:
-#                        type: string
-#                        example: CanonicalUser
-#                      uri:
-#                        type: string
-#                        example: uri
-#                  permission:
-#                    type: string
-#                    example: permission
 
     # Note: Permissions/Permission/Permission[s]ResponseBodyに分離
     Permissions:
@@ -1903,45 +1749,6 @@ components:
         - id
         - secret
         - created_at
-
-#    Session:
-#      description: Session
-#      type: object
-#      properties:
-#        data:
-#          type: object
-#          properties:
-#            access_key_id:
-#              type: string
-#              example: abcdefABCDEF0123456789
-#            access_key_secret:
-#              type: string
-#              pattern: '^[\w\d\/]{1,40}$'
-#              example: abcdefABCDEF0123456789
-#            user:
-#              type: string
-#              example: user_name
-#            created_at:
-#              allOf:
-#                - $ref: '#/components/schemas/CreatedAt'
-#            expired_at:
-#              type: string
-#              format: date-time
-#              example: '2021-01-11T01:11:23.123456+09:00'
-#    SessionBody:
-#      description: Session body
-#      type: object
-#      properties:
-#        expires_at:
-#          type: string
-#          format: date-time
-#          example: '2020-01-11T01:11:23.123456+09:00'
-#        token:
-#          type: string
-#          example: abcdefABCDEF0123456789
-#        user:
-#          type: string
-#          example: user_name
 
     # Note: StatusResponseBodyを切り出し
     Status:
@@ -2109,3 +1916,15 @@ components:
         - message
         - trace_id
         - errors
+
+tags:
+  - name: サイト
+    description: サイトに関する情報
+  - name: バケット
+    description: バケットに関する情報
+  - name: サイトアカウント
+    description: サイトアカウントに関する情報
+  - name: パーミッション
+    description: パーミッションに関する情報
+  - name: ステータス
+    description: ステータスに関する情報

--- a/apis/v1/zz_client_gen.go
+++ b/apis/v1/zz_client_gen.go
@@ -114,35 +114,35 @@ type ClientInterface interface {
 
 	CreateBucket(ctx context.Context, bucketName BucketName, body CreateBucketJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListClusters request
-	ListClusters(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetClusters request
+	GetClusters(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ReadCluster request
-	ReadCluster(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetCluster request
+	GetCluster(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DeleteSiteAccount request
-	DeleteSiteAccount(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// DeleteAccount request
+	DeleteAccount(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ReadSiteAccount request
-	ReadSiteAccount(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetAccount request
+	GetAccount(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// CreateSiteAccount request
-	CreateSiteAccount(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// CreateAccount request
+	CreateAccount(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListAccountAccessKeys request
-	ListAccountAccessKeys(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetAccountKeys request
+	GetAccountKeys(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// CreateAccountAccessKey request
-	CreateAccountAccessKey(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// CreateAccountKey request
+	CreateAccountKey(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DeleteAccountAccessKey request
-	DeleteAccountAccessKey(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// DeleteAccountKey request
+	DeleteAccountKey(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ReadAccountAccessKey request
-	ReadAccountAccessKey(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetAccountKey request
+	GetAccountKey(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListPermissions request
-	ListPermissions(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPermissions request
+	GetPermissions(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreatePermission request with any body
 	CreatePermissionWithBody(ctx context.Context, siteId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -152,28 +152,28 @@ type ClientInterface interface {
 	// DeletePermission request
 	DeletePermission(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ReadPermission request
-	ReadPermission(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPermission request
+	GetPermission(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UpdatePermission request with any body
 	UpdatePermissionWithBody(ctx context.Context, siteId string, permissionId PermissionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdatePermission(ctx context.Context, siteId string, permissionId PermissionID, body UpdatePermissionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ListPermissionAccessKeys request
-	ListPermissionAccessKeys(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPermissionKeys request
+	GetPermissionKeys(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// CreatePermissionAccessKey request
-	CreatePermissionAccessKey(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// CreatePermissionKey request
+	CreatePermissionKey(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DeletePermissionAccessKey request
-	DeletePermissionAccessKey(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// DeletePermissionKey request
+	DeletePermissionKey(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ReadPermissionAccessKey request
-	ReadPermissionAccessKey(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPermissionKey request
+	GetPermissionKey(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ReadSiteStatus request
-	ReadSiteStatus(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetStatus request
+	GetStatus(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) DeleteBucketWithBody(ctx context.Context, bucketName BucketName, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -224,8 +224,8 @@ func (c *Client) CreateBucket(ctx context.Context, bucketName BucketName, body C
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListClusters(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListClustersRequest(c.Server)
+func (c *Client) GetClusters(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetClustersRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -236,8 +236,8 @@ func (c *Client) ListClusters(ctx context.Context, reqEditors ...RequestEditorFn
 	return c.Client.Do(req)
 }
 
-func (c *Client) ReadCluster(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewReadClusterRequest(c.Server, siteId)
+func (c *Client) GetCluster(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetClusterRequest(c.Server, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -248,8 +248,8 @@ func (c *Client) ReadCluster(ctx context.Context, siteId string, reqEditors ...R
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteSiteAccount(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteSiteAccountRequest(c.Server, siteId)
+func (c *Client) DeleteAccount(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteAccountRequest(c.Server, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -260,8 +260,8 @@ func (c *Client) DeleteSiteAccount(ctx context.Context, siteId string, reqEditor
 	return c.Client.Do(req)
 }
 
-func (c *Client) ReadSiteAccount(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewReadSiteAccountRequest(c.Server, siteId)
+func (c *Client) GetAccount(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAccountRequest(c.Server, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -272,8 +272,8 @@ func (c *Client) ReadSiteAccount(ctx context.Context, siteId string, reqEditors 
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateSiteAccount(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateSiteAccountRequest(c.Server, siteId)
+func (c *Client) CreateAccount(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateAccountRequest(c.Server, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -284,8 +284,8 @@ func (c *Client) CreateSiteAccount(ctx context.Context, siteId string, reqEditor
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListAccountAccessKeys(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListAccountAccessKeysRequest(c.Server, siteId)
+func (c *Client) GetAccountKeys(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAccountKeysRequest(c.Server, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -296,8 +296,8 @@ func (c *Client) ListAccountAccessKeys(ctx context.Context, siteId string, reqEd
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateAccountAccessKey(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateAccountAccessKeyRequest(c.Server, siteId)
+func (c *Client) CreateAccountKey(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateAccountKeyRequest(c.Server, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -308,8 +308,8 @@ func (c *Client) CreateAccountAccessKey(ctx context.Context, siteId string, reqE
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteAccountAccessKey(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteAccountAccessKeyRequest(c.Server, siteId, accountKeyId)
+func (c *Client) DeleteAccountKey(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteAccountKeyRequest(c.Server, siteId, accountKeyId)
 	if err != nil {
 		return nil, err
 	}
@@ -320,8 +320,8 @@ func (c *Client) DeleteAccountAccessKey(ctx context.Context, siteId string, acco
 	return c.Client.Do(req)
 }
 
-func (c *Client) ReadAccountAccessKey(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewReadAccountAccessKeyRequest(c.Server, siteId, accountKeyId)
+func (c *Client) GetAccountKey(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAccountKeyRequest(c.Server, siteId, accountKeyId)
 	if err != nil {
 		return nil, err
 	}
@@ -332,8 +332,8 @@ func (c *Client) ReadAccountAccessKey(ctx context.Context, siteId string, accoun
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListPermissions(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListPermissionsRequest(c.Server, siteId)
+func (c *Client) GetPermissions(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPermissionsRequest(c.Server, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -380,8 +380,8 @@ func (c *Client) DeletePermission(ctx context.Context, siteId string, permission
 	return c.Client.Do(req)
 }
 
-func (c *Client) ReadPermission(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewReadPermissionRequest(c.Server, siteId, permissionId)
+func (c *Client) GetPermission(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPermissionRequest(c.Server, siteId, permissionId)
 	if err != nil {
 		return nil, err
 	}
@@ -416,8 +416,8 @@ func (c *Client) UpdatePermission(ctx context.Context, siteId string, permission
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListPermissionAccessKeys(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListPermissionAccessKeysRequest(c.Server, siteId, permissionId)
+func (c *Client) GetPermissionKeys(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPermissionKeysRequest(c.Server, siteId, permissionId)
 	if err != nil {
 		return nil, err
 	}
@@ -428,8 +428,8 @@ func (c *Client) ListPermissionAccessKeys(ctx context.Context, siteId string, pe
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreatePermissionAccessKey(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreatePermissionAccessKeyRequest(c.Server, siteId, permissionId)
+func (c *Client) CreatePermissionKey(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreatePermissionKeyRequest(c.Server, siteId, permissionId)
 	if err != nil {
 		return nil, err
 	}
@@ -440,8 +440,8 @@ func (c *Client) CreatePermissionAccessKey(ctx context.Context, siteId string, p
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeletePermissionAccessKey(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeletePermissionAccessKeyRequest(c.Server, siteId, permissionId, permissionKeyId)
+func (c *Client) DeletePermissionKey(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeletePermissionKeyRequest(c.Server, siteId, permissionId, permissionKeyId)
 	if err != nil {
 		return nil, err
 	}
@@ -452,8 +452,8 @@ func (c *Client) DeletePermissionAccessKey(ctx context.Context, siteId string, p
 	return c.Client.Do(req)
 }
 
-func (c *Client) ReadPermissionAccessKey(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewReadPermissionAccessKeyRequest(c.Server, siteId, permissionId, permissionKeyId)
+func (c *Client) GetPermissionKey(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPermissionKeyRequest(c.Server, siteId, permissionId, permissionKeyId)
 	if err != nil {
 		return nil, err
 	}
@@ -464,8 +464,8 @@ func (c *Client) ReadPermissionAccessKey(ctx context.Context, siteId string, per
 	return c.Client.Do(req)
 }
 
-func (c *Client) ReadSiteStatus(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewReadSiteStatusRequest(c.Server, siteId)
+func (c *Client) GetStatus(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetStatusRequest(c.Server, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -570,8 +570,8 @@ func NewCreateBucketRequestWithBody(server string, bucketName BucketName, conten
 	return req, nil
 }
 
-// NewListClustersRequest generates requests for ListClusters
-func NewListClustersRequest(server string) (*http.Request, error) {
+// NewGetClustersRequest generates requests for GetClusters
+func NewGetClustersRequest(server string) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -597,8 +597,8 @@ func NewListClustersRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
-// NewReadClusterRequest generates requests for ReadCluster
-func NewReadClusterRequest(server string, siteId string) (*http.Request, error) {
+// NewGetClusterRequest generates requests for GetCluster
+func NewGetClusterRequest(server string, siteId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -631,8 +631,8 @@ func NewReadClusterRequest(server string, siteId string) (*http.Request, error) 
 	return req, nil
 }
 
-// NewDeleteSiteAccountRequest generates requests for DeleteSiteAccount
-func NewDeleteSiteAccountRequest(server string, siteId string) (*http.Request, error) {
+// NewDeleteAccountRequest generates requests for DeleteAccount
+func NewDeleteAccountRequest(server string, siteId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -665,8 +665,8 @@ func NewDeleteSiteAccountRequest(server string, siteId string) (*http.Request, e
 	return req, nil
 }
 
-// NewReadSiteAccountRequest generates requests for ReadSiteAccount
-func NewReadSiteAccountRequest(server string, siteId string) (*http.Request, error) {
+// NewGetAccountRequest generates requests for GetAccount
+func NewGetAccountRequest(server string, siteId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -699,8 +699,8 @@ func NewReadSiteAccountRequest(server string, siteId string) (*http.Request, err
 	return req, nil
 }
 
-// NewCreateSiteAccountRequest generates requests for CreateSiteAccount
-func NewCreateSiteAccountRequest(server string, siteId string) (*http.Request, error) {
+// NewCreateAccountRequest generates requests for CreateAccount
+func NewCreateAccountRequest(server string, siteId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -733,8 +733,8 @@ func NewCreateSiteAccountRequest(server string, siteId string) (*http.Request, e
 	return req, nil
 }
 
-// NewListAccountAccessKeysRequest generates requests for ListAccountAccessKeys
-func NewListAccountAccessKeysRequest(server string, siteId string) (*http.Request, error) {
+// NewGetAccountKeysRequest generates requests for GetAccountKeys
+func NewGetAccountKeysRequest(server string, siteId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -767,8 +767,8 @@ func NewListAccountAccessKeysRequest(server string, siteId string) (*http.Reques
 	return req, nil
 }
 
-// NewCreateAccountAccessKeyRequest generates requests for CreateAccountAccessKey
-func NewCreateAccountAccessKeyRequest(server string, siteId string) (*http.Request, error) {
+// NewCreateAccountKeyRequest generates requests for CreateAccountKey
+func NewCreateAccountKeyRequest(server string, siteId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -801,8 +801,8 @@ func NewCreateAccountAccessKeyRequest(server string, siteId string) (*http.Reque
 	return req, nil
 }
 
-// NewDeleteAccountAccessKeyRequest generates requests for DeleteAccountAccessKey
-func NewDeleteAccountAccessKeyRequest(server string, siteId string, accountKeyId AccessKeyID) (*http.Request, error) {
+// NewDeleteAccountKeyRequest generates requests for DeleteAccountKey
+func NewDeleteAccountKeyRequest(server string, siteId string, accountKeyId AccessKeyID) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -842,8 +842,8 @@ func NewDeleteAccountAccessKeyRequest(server string, siteId string, accountKeyId
 	return req, nil
 }
 
-// NewReadAccountAccessKeyRequest generates requests for ReadAccountAccessKey
-func NewReadAccountAccessKeyRequest(server string, siteId string, accountKeyId AccessKeyID) (*http.Request, error) {
+// NewGetAccountKeyRequest generates requests for GetAccountKey
+func NewGetAccountKeyRequest(server string, siteId string, accountKeyId AccessKeyID) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -883,8 +883,8 @@ func NewReadAccountAccessKeyRequest(server string, siteId string, accountKeyId A
 	return req, nil
 }
 
-// NewListPermissionsRequest generates requests for ListPermissions
-func NewListPermissionsRequest(server string, siteId string) (*http.Request, error) {
+// NewGetPermissionsRequest generates requests for GetPermissions
+func NewGetPermissionsRequest(server string, siteId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1005,8 +1005,8 @@ func NewDeletePermissionRequest(server string, siteId string, permissionId Permi
 	return req, nil
 }
 
-// NewReadPermissionRequest generates requests for ReadPermission
-func NewReadPermissionRequest(server string, siteId string, permissionId PermissionID) (*http.Request, error) {
+// NewGetPermissionRequest generates requests for GetPermission
+func NewGetPermissionRequest(server string, siteId string, permissionId PermissionID) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1100,8 +1100,8 @@ func NewUpdatePermissionRequestWithBody(server string, siteId string, permission
 	return req, nil
 }
 
-// NewListPermissionAccessKeysRequest generates requests for ListPermissionAccessKeys
-func NewListPermissionAccessKeysRequest(server string, siteId string, permissionId PermissionID) (*http.Request, error) {
+// NewGetPermissionKeysRequest generates requests for GetPermissionKeys
+func NewGetPermissionKeysRequest(server string, siteId string, permissionId PermissionID) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1141,8 +1141,8 @@ func NewListPermissionAccessKeysRequest(server string, siteId string, permission
 	return req, nil
 }
 
-// NewCreatePermissionAccessKeyRequest generates requests for CreatePermissionAccessKey
-func NewCreatePermissionAccessKeyRequest(server string, siteId string, permissionId PermissionID) (*http.Request, error) {
+// NewCreatePermissionKeyRequest generates requests for CreatePermissionKey
+func NewCreatePermissionKeyRequest(server string, siteId string, permissionId PermissionID) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1182,8 +1182,8 @@ func NewCreatePermissionAccessKeyRequest(server string, siteId string, permissio
 	return req, nil
 }
 
-// NewDeletePermissionAccessKeyRequest generates requests for DeletePermissionAccessKey
-func NewDeletePermissionAccessKeyRequest(server string, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID) (*http.Request, error) {
+// NewDeletePermissionKeyRequest generates requests for DeletePermissionKey
+func NewDeletePermissionKeyRequest(server string, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1230,8 +1230,8 @@ func NewDeletePermissionAccessKeyRequest(server string, siteId string, permissio
 	return req, nil
 }
 
-// NewReadPermissionAccessKeyRequest generates requests for ReadPermissionAccessKey
-func NewReadPermissionAccessKeyRequest(server string, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID) (*http.Request, error) {
+// NewGetPermissionKeyRequest generates requests for GetPermissionKey
+func NewGetPermissionKeyRequest(server string, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1278,8 +1278,8 @@ func NewReadPermissionAccessKeyRequest(server string, siteId string, permissionI
 	return req, nil
 }
 
-// NewReadSiteStatusRequest generates requests for ReadSiteStatus
-func NewReadSiteStatusRequest(server string, siteId string) (*http.Request, error) {
+// NewGetStatusRequest generates requests for GetStatus
+func NewGetStatusRequest(server string, siteId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1365,35 +1365,35 @@ type ClientWithResponsesInterface interface {
 
 	CreateBucketWithResponse(ctx context.Context, bucketName BucketName, body CreateBucketJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateBucketResponse, error)
 
-	// ListClusters request
-	ListClustersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListClustersResponse, error)
+	// GetClusters request
+	GetClustersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetClustersResponse, error)
 
-	// ReadCluster request
-	ReadClusterWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*ReadClusterResponse, error)
+	// GetCluster request
+	GetClusterWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*GetClusterResponse, error)
 
-	// DeleteSiteAccount request
-	DeleteSiteAccountWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*DeleteSiteAccountResponse, error)
+	// DeleteAccount request
+	DeleteAccountWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*DeleteAccountResponse, error)
 
-	// ReadSiteAccount request
-	ReadSiteAccountWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*ReadSiteAccountResponse, error)
+	// GetAccount request
+	GetAccountWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*GetAccountResponse, error)
 
-	// CreateSiteAccount request
-	CreateSiteAccountWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*CreateSiteAccountResponse, error)
+	// CreateAccount request
+	CreateAccountWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*CreateAccountResponse, error)
 
-	// ListAccountAccessKeys request
-	ListAccountAccessKeysWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*ListAccountAccessKeysResponse, error)
+	// GetAccountKeys request
+	GetAccountKeysWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*GetAccountKeysResponse, error)
 
-	// CreateAccountAccessKey request
-	CreateAccountAccessKeyWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*CreateAccountAccessKeyResponse, error)
+	// CreateAccountKey request
+	CreateAccountKeyWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*CreateAccountKeyResponse, error)
 
-	// DeleteAccountAccessKey request
-	DeleteAccountAccessKeyWithResponse(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*DeleteAccountAccessKeyResponse, error)
+	// DeleteAccountKey request
+	DeleteAccountKeyWithResponse(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*DeleteAccountKeyResponse, error)
 
-	// ReadAccountAccessKey request
-	ReadAccountAccessKeyWithResponse(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*ReadAccountAccessKeyResponse, error)
+	// GetAccountKey request
+	GetAccountKeyWithResponse(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*GetAccountKeyResponse, error)
 
-	// ListPermissions request
-	ListPermissionsWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*ListPermissionsResponse, error)
+	// GetPermissions request
+	GetPermissionsWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*GetPermissionsResponse, error)
 
 	// CreatePermission request with any body
 	CreatePermissionWithBodyWithResponse(ctx context.Context, siteId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreatePermissionResponse, error)
@@ -1403,28 +1403,28 @@ type ClientWithResponsesInterface interface {
 	// DeletePermission request
 	DeletePermissionWithResponse(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*DeletePermissionResponse, error)
 
-	// ReadPermission request
-	ReadPermissionWithResponse(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*ReadPermissionResponse, error)
+	// GetPermission request
+	GetPermissionWithResponse(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*GetPermissionResponse, error)
 
 	// UpdatePermission request with any body
 	UpdatePermissionWithBodyWithResponse(ctx context.Context, siteId string, permissionId PermissionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdatePermissionResponse, error)
 
 	UpdatePermissionWithResponse(ctx context.Context, siteId string, permissionId PermissionID, body UpdatePermissionJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdatePermissionResponse, error)
 
-	// ListPermissionAccessKeys request
-	ListPermissionAccessKeysWithResponse(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*ListPermissionAccessKeysResponse, error)
+	// GetPermissionKeys request
+	GetPermissionKeysWithResponse(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*GetPermissionKeysResponse, error)
 
-	// CreatePermissionAccessKey request
-	CreatePermissionAccessKeyWithResponse(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*CreatePermissionAccessKeyResponse, error)
+	// CreatePermissionKey request
+	CreatePermissionKeyWithResponse(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*CreatePermissionKeyResponse, error)
 
-	// DeletePermissionAccessKey request
-	DeletePermissionAccessKeyWithResponse(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*DeletePermissionAccessKeyResponse, error)
+	// DeletePermissionKey request
+	DeletePermissionKeyWithResponse(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*DeletePermissionKeyResponse, error)
 
-	// ReadPermissionAccessKey request
-	ReadPermissionAccessKeyWithResponse(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*ReadPermissionAccessKeyResponse, error)
+	// GetPermissionKey request
+	GetPermissionKeyWithResponse(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*GetPermissionKeyResponse, error)
 
-	// ReadSiteStatus request
-	ReadSiteStatusWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*ReadSiteStatusResponse, error)
+	// GetStatus request
+	GetStatusWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*GetStatusResponse, error)
 }
 
 type DeleteBucketResponse struct {
@@ -1501,7 +1501,7 @@ func (r CreateBucketResponse) UndefinedError() error {
 	return nil
 }
 
-type ListClustersResponse struct {
+type GetClustersResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *ListClustersResponseBody
@@ -1509,7 +1509,7 @@ type ListClustersResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListClustersResponse) Status() string {
+func (r GetClustersResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1517,7 +1517,7 @@ func (r ListClustersResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListClustersResponse) StatusCode() int {
+func (r GetClustersResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1525,19 +1525,19 @@ func (r ListClustersResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r ListClustersResponse) Result() (*ListClustersResponseBody, error) {
+func (r GetClustersResponse) Result() (*ListClustersResponseBody, error) {
 	return r.JSON200, eCoalesce(r.JSON401, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r ListClustersResponse) UndefinedError() error {
+func (r GetClustersResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
 	return nil
 }
 
-type ReadClusterResponse struct {
+type GetClusterResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *ReadClusterResponseBody
@@ -1546,7 +1546,7 @@ type ReadClusterResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ReadClusterResponse) Status() string {
+func (r GetClusterResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1554,7 +1554,7 @@ func (r ReadClusterResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ReadClusterResponse) StatusCode() int {
+func (r GetClusterResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1562,19 +1562,19 @@ func (r ReadClusterResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r ReadClusterResponse) Result() (*ReadClusterResponseBody, error) {
+func (r GetClusterResponse) Result() (*ReadClusterResponseBody, error) {
 	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r ReadClusterResponse) UndefinedError() error {
+func (r GetClusterResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
 	return nil
 }
 
-type DeleteSiteAccountResponse struct {
+type DeleteAccountResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON401      *Error401
@@ -1582,7 +1582,7 @@ type DeleteSiteAccountResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r DeleteSiteAccountResponse) Status() string {
+func (r DeleteAccountResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1590,7 +1590,7 @@ func (r DeleteSiteAccountResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r DeleteSiteAccountResponse) StatusCode() int {
+func (r DeleteAccountResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1598,19 +1598,19 @@ func (r DeleteSiteAccountResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r DeleteSiteAccountResponse) Result() error {
+func (r DeleteAccountResponse) Result() error {
 	return eCoalesce(r.JSON401, r.JSON409, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r DeleteSiteAccountResponse) UndefinedError() error {
+func (r DeleteAccountResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
 	return nil
 }
 
-type ReadSiteAccountResponse struct {
+type GetAccountResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *AccountResponseBody
@@ -1620,7 +1620,7 @@ type ReadSiteAccountResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ReadSiteAccountResponse) Status() string {
+func (r GetAccountResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1628,7 +1628,7 @@ func (r ReadSiteAccountResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ReadSiteAccountResponse) StatusCode() int {
+func (r GetAccountResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1636,19 +1636,19 @@ func (r ReadSiteAccountResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r ReadSiteAccountResponse) Result() (*AccountResponseBody, error) {
+func (r GetAccountResponse) Result() (*AccountResponseBody, error) {
 	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.JSONDefault, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r ReadSiteAccountResponse) UndefinedError() error {
+func (r GetAccountResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
 	return nil
 }
 
-type CreateSiteAccountResponse struct {
+type CreateAccountResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON201      *AccountResponseBody
@@ -1659,7 +1659,7 @@ type CreateSiteAccountResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r CreateSiteAccountResponse) Status() string {
+func (r CreateAccountResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1667,7 +1667,7 @@ func (r CreateSiteAccountResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r CreateSiteAccountResponse) StatusCode() int {
+func (r CreateAccountResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1675,19 +1675,19 @@ func (r CreateSiteAccountResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r CreateSiteAccountResponse) Result() (*AccountResponseBody, error) {
+func (r CreateAccountResponse) Result() (*AccountResponseBody, error) {
 	return r.JSON201, eCoalesce(r.JSON401, r.JSON403, r.JSON409, r.JSONDefault, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r CreateSiteAccountResponse) UndefinedError() error {
+func (r CreateAccountResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
 	return nil
 }
 
-type ListAccountAccessKeysResponse struct {
+type GetAccountKeysResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *AccountKeysResponseBody
@@ -1697,7 +1697,7 @@ type ListAccountAccessKeysResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListAccountAccessKeysResponse) Status() string {
+func (r GetAccountKeysResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1705,7 +1705,7 @@ func (r ListAccountAccessKeysResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListAccountAccessKeysResponse) StatusCode() int {
+func (r GetAccountKeysResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1713,19 +1713,19 @@ func (r ListAccountAccessKeysResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r ListAccountAccessKeysResponse) Result() (*AccountKeysResponseBody, error) {
+func (r GetAccountKeysResponse) Result() (*AccountKeysResponseBody, error) {
 	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.JSONDefault, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r ListAccountAccessKeysResponse) UndefinedError() error {
+func (r GetAccountKeysResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
 	return nil
 }
 
-type CreateAccountAccessKeyResponse struct {
+type CreateAccountKeyResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON201      *AccountKeyResponseBody
@@ -1736,7 +1736,7 @@ type CreateAccountAccessKeyResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r CreateAccountAccessKeyResponse) Status() string {
+func (r CreateAccountKeyResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1744,7 +1744,7 @@ func (r CreateAccountAccessKeyResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r CreateAccountAccessKeyResponse) StatusCode() int {
+func (r CreateAccountKeyResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1752,26 +1752,26 @@ func (r CreateAccountAccessKeyResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r CreateAccountAccessKeyResponse) Result() (*AccountKeyResponseBody, error) {
+func (r CreateAccountKeyResponse) Result() (*AccountKeyResponseBody, error) {
 	return r.JSON201, eCoalesce(r.JSON401, r.JSON404, r.JSON409, r.JSONDefault, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r CreateAccountAccessKeyResponse) UndefinedError() error {
+func (r CreateAccountKeyResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
 	return nil
 }
 
-type DeleteAccountAccessKeyResponse struct {
+type DeleteAccountKeyResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON401      *Error401
 }
 
 // Status returns HTTPResponse.Status
-func (r DeleteAccountAccessKeyResponse) Status() string {
+func (r DeleteAccountKeyResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1779,7 +1779,7 @@ func (r DeleteAccountAccessKeyResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r DeleteAccountAccessKeyResponse) StatusCode() int {
+func (r DeleteAccountKeyResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1787,19 +1787,19 @@ func (r DeleteAccountAccessKeyResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r DeleteAccountAccessKeyResponse) Result() error {
+func (r DeleteAccountKeyResponse) Result() error {
 	return eCoalesce(r.JSON401, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r DeleteAccountAccessKeyResponse) UndefinedError() error {
+func (r DeleteAccountKeyResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
 	return nil
 }
 
-type ReadAccountAccessKeyResponse struct {
+type GetAccountKeyResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *AccountKeyResponseBody
@@ -1809,7 +1809,7 @@ type ReadAccountAccessKeyResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ReadAccountAccessKeyResponse) Status() string {
+func (r GetAccountKeyResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1817,7 +1817,7 @@ func (r ReadAccountAccessKeyResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ReadAccountAccessKeyResponse) StatusCode() int {
+func (r GetAccountKeyResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1825,19 +1825,19 @@ func (r ReadAccountAccessKeyResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r ReadAccountAccessKeyResponse) Result() (*AccountKeyResponseBody, error) {
+func (r GetAccountKeyResponse) Result() (*AccountKeyResponseBody, error) {
 	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.JSONDefault, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r ReadAccountAccessKeyResponse) UndefinedError() error {
+func (r GetAccountKeyResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
 	return nil
 }
 
-type ListPermissionsResponse struct {
+type GetPermissionsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *PermissionsResponseBody
@@ -1846,7 +1846,7 @@ type ListPermissionsResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListPermissionsResponse) Status() string {
+func (r GetPermissionsResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1854,7 +1854,7 @@ func (r ListPermissionsResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListPermissionsResponse) StatusCode() int {
+func (r GetPermissionsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1862,12 +1862,12 @@ func (r ListPermissionsResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r ListPermissionsResponse) Result() (*PermissionsResponseBody, error) {
+func (r GetPermissionsResponse) Result() (*PermissionsResponseBody, error) {
 	return r.JSON200, eCoalesce(r.JSON401, r.JSONDefault, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r ListPermissionsResponse) UndefinedError() error {
+func (r GetPermissionsResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
@@ -1948,7 +1948,7 @@ func (r DeletePermissionResponse) UndefinedError() error {
 	return nil
 }
 
-type ReadPermissionResponse struct {
+type GetPermissionResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *PermissionResponseBody
@@ -1958,7 +1958,7 @@ type ReadPermissionResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ReadPermissionResponse) Status() string {
+func (r GetPermissionResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1966,7 +1966,7 @@ func (r ReadPermissionResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ReadPermissionResponse) StatusCode() int {
+func (r GetPermissionResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1974,12 +1974,12 @@ func (r ReadPermissionResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r ReadPermissionResponse) Result() (*PermissionResponseBody, error) {
+func (r GetPermissionResponse) Result() (*PermissionResponseBody, error) {
 	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.JSONDefault, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r ReadPermissionResponse) UndefinedError() error {
+func (r GetPermissionResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
@@ -2025,7 +2025,7 @@ func (r UpdatePermissionResponse) UndefinedError() error {
 	return nil
 }
 
-type ListPermissionAccessKeysResponse struct {
+type GetPermissionKeysResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *PermissionKeysResponseBody
@@ -2035,7 +2035,7 @@ type ListPermissionAccessKeysResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ListPermissionAccessKeysResponse) Status() string {
+func (r GetPermissionKeysResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -2043,7 +2043,7 @@ func (r ListPermissionAccessKeysResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ListPermissionAccessKeysResponse) StatusCode() int {
+func (r GetPermissionKeysResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -2051,19 +2051,19 @@ func (r ListPermissionAccessKeysResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r ListPermissionAccessKeysResponse) Result() (*PermissionKeysResponseBody, error) {
+func (r GetPermissionKeysResponse) Result() (*PermissionKeysResponseBody, error) {
 	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.JSONDefault, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r ListPermissionAccessKeysResponse) UndefinedError() error {
+func (r GetPermissionKeysResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
 	return nil
 }
 
-type CreatePermissionAccessKeyResponse struct {
+type CreatePermissionKeyResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON201      *PermissionKeyResponseBody
@@ -2074,7 +2074,7 @@ type CreatePermissionAccessKeyResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r CreatePermissionAccessKeyResponse) Status() string {
+func (r CreatePermissionKeyResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -2082,7 +2082,7 @@ func (r CreatePermissionAccessKeyResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r CreatePermissionAccessKeyResponse) StatusCode() int {
+func (r CreatePermissionKeyResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -2090,19 +2090,19 @@ func (r CreatePermissionAccessKeyResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r CreatePermissionAccessKeyResponse) Result() (*PermissionKeyResponseBody, error) {
+func (r CreatePermissionKeyResponse) Result() (*PermissionKeyResponseBody, error) {
 	return r.JSON201, eCoalesce(r.JSON401, r.JSON404, r.JSON409, r.JSONDefault, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r CreatePermissionAccessKeyResponse) UndefinedError() error {
+func (r CreatePermissionKeyResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
 	return nil
 }
 
-type DeletePermissionAccessKeyResponse struct {
+type DeletePermissionKeyResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON401      *Error401
@@ -2110,7 +2110,7 @@ type DeletePermissionAccessKeyResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r DeletePermissionAccessKeyResponse) Status() string {
+func (r DeletePermissionKeyResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -2118,7 +2118,7 @@ func (r DeletePermissionAccessKeyResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r DeletePermissionAccessKeyResponse) StatusCode() int {
+func (r DeletePermissionKeyResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -2126,19 +2126,19 @@ func (r DeletePermissionAccessKeyResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r DeletePermissionAccessKeyResponse) Result() error {
+func (r DeletePermissionKeyResponse) Result() error {
 	return eCoalesce(r.JSON401, r.JSON404, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r DeletePermissionAccessKeyResponse) UndefinedError() error {
+func (r DeletePermissionKeyResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
 	return nil
 }
 
-type ReadPermissionAccessKeyResponse struct {
+type GetPermissionKeyResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *PermissionKeyResponseBody
@@ -2148,7 +2148,7 @@ type ReadPermissionAccessKeyResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ReadPermissionAccessKeyResponse) Status() string {
+func (r GetPermissionKeyResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -2156,7 +2156,7 @@ func (r ReadPermissionAccessKeyResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ReadPermissionAccessKeyResponse) StatusCode() int {
+func (r GetPermissionKeyResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -2164,19 +2164,19 @@ func (r ReadPermissionAccessKeyResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r ReadPermissionAccessKeyResponse) Result() (*PermissionKeyResponseBody, error) {
+func (r GetPermissionKeyResponse) Result() (*PermissionKeyResponseBody, error) {
 	return r.JSON200, eCoalesce(r.JSON401, r.JSON404, r.JSONDefault, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r ReadPermissionAccessKeyResponse) UndefinedError() error {
+func (r GetPermissionKeyResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
 	return nil
 }
 
-type ReadSiteStatusResponse struct {
+type GetStatusResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *StatusResponseBody
@@ -2185,7 +2185,7 @@ type ReadSiteStatusResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r ReadSiteStatusResponse) Status() string {
+func (r GetStatusResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -2193,7 +2193,7 @@ func (r ReadSiteStatusResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ReadSiteStatusResponse) StatusCode() int {
+func (r GetStatusResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -2201,12 +2201,12 @@ func (r ReadSiteStatusResponse) StatusCode() int {
 }
 
 // Result JSON200の結果、もしくは発生したエラーのいずれかを返す
-func (r ReadSiteStatusResponse) Result() (*StatusResponseBody, error) {
+func (r GetStatusResponse) Result() (*StatusResponseBody, error) {
 	return r.JSON200, eCoalesce(r.JSON401, r.JSONDefault, r.UndefinedError())
 }
 
 // UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
-func (r ReadSiteStatusResponse) UndefinedError() error {
+func (r GetStatusResponse) UndefinedError() error {
 	if !isOKStatus(r.HTTPResponse.StatusCode) {
 		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
 	}
@@ -2247,94 +2247,94 @@ func (c *ClientWithResponses) CreateBucketWithResponse(ctx context.Context, buck
 	return ParseCreateBucketResponse(rsp)
 }
 
-// ListClustersWithResponse request returning *ListClustersResponse
-func (c *ClientWithResponses) ListClustersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListClustersResponse, error) {
-	rsp, err := c.ListClusters(ctx, reqEditors...)
+// GetClustersWithResponse request returning *GetClustersResponse
+func (c *ClientWithResponses) GetClustersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetClustersResponse, error) {
+	rsp, err := c.GetClusters(ctx, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseListClustersResponse(rsp)
+	return ParseGetClustersResponse(rsp)
 }
 
-// ReadClusterWithResponse request returning *ReadClusterResponse
-func (c *ClientWithResponses) ReadClusterWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*ReadClusterResponse, error) {
-	rsp, err := c.ReadCluster(ctx, siteId, reqEditors...)
+// GetClusterWithResponse request returning *GetClusterResponse
+func (c *ClientWithResponses) GetClusterWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*GetClusterResponse, error) {
+	rsp, err := c.GetCluster(ctx, siteId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseReadClusterResponse(rsp)
+	return ParseGetClusterResponse(rsp)
 }
 
-// DeleteSiteAccountWithResponse request returning *DeleteSiteAccountResponse
-func (c *ClientWithResponses) DeleteSiteAccountWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*DeleteSiteAccountResponse, error) {
-	rsp, err := c.DeleteSiteAccount(ctx, siteId, reqEditors...)
+// DeleteAccountWithResponse request returning *DeleteAccountResponse
+func (c *ClientWithResponses) DeleteAccountWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*DeleteAccountResponse, error) {
+	rsp, err := c.DeleteAccount(ctx, siteId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseDeleteSiteAccountResponse(rsp)
+	return ParseDeleteAccountResponse(rsp)
 }
 
-// ReadSiteAccountWithResponse request returning *ReadSiteAccountResponse
-func (c *ClientWithResponses) ReadSiteAccountWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*ReadSiteAccountResponse, error) {
-	rsp, err := c.ReadSiteAccount(ctx, siteId, reqEditors...)
+// GetAccountWithResponse request returning *GetAccountResponse
+func (c *ClientWithResponses) GetAccountWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*GetAccountResponse, error) {
+	rsp, err := c.GetAccount(ctx, siteId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseReadSiteAccountResponse(rsp)
+	return ParseGetAccountResponse(rsp)
 }
 
-// CreateSiteAccountWithResponse request returning *CreateSiteAccountResponse
-func (c *ClientWithResponses) CreateSiteAccountWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*CreateSiteAccountResponse, error) {
-	rsp, err := c.CreateSiteAccount(ctx, siteId, reqEditors...)
+// CreateAccountWithResponse request returning *CreateAccountResponse
+func (c *ClientWithResponses) CreateAccountWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*CreateAccountResponse, error) {
+	rsp, err := c.CreateAccount(ctx, siteId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseCreateSiteAccountResponse(rsp)
+	return ParseCreateAccountResponse(rsp)
 }
 
-// ListAccountAccessKeysWithResponse request returning *ListAccountAccessKeysResponse
-func (c *ClientWithResponses) ListAccountAccessKeysWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*ListAccountAccessKeysResponse, error) {
-	rsp, err := c.ListAccountAccessKeys(ctx, siteId, reqEditors...)
+// GetAccountKeysWithResponse request returning *GetAccountKeysResponse
+func (c *ClientWithResponses) GetAccountKeysWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*GetAccountKeysResponse, error) {
+	rsp, err := c.GetAccountKeys(ctx, siteId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseListAccountAccessKeysResponse(rsp)
+	return ParseGetAccountKeysResponse(rsp)
 }
 
-// CreateAccountAccessKeyWithResponse request returning *CreateAccountAccessKeyResponse
-func (c *ClientWithResponses) CreateAccountAccessKeyWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*CreateAccountAccessKeyResponse, error) {
-	rsp, err := c.CreateAccountAccessKey(ctx, siteId, reqEditors...)
+// CreateAccountKeyWithResponse request returning *CreateAccountKeyResponse
+func (c *ClientWithResponses) CreateAccountKeyWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*CreateAccountKeyResponse, error) {
+	rsp, err := c.CreateAccountKey(ctx, siteId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseCreateAccountAccessKeyResponse(rsp)
+	return ParseCreateAccountKeyResponse(rsp)
 }
 
-// DeleteAccountAccessKeyWithResponse request returning *DeleteAccountAccessKeyResponse
-func (c *ClientWithResponses) DeleteAccountAccessKeyWithResponse(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*DeleteAccountAccessKeyResponse, error) {
-	rsp, err := c.DeleteAccountAccessKey(ctx, siteId, accountKeyId, reqEditors...)
+// DeleteAccountKeyWithResponse request returning *DeleteAccountKeyResponse
+func (c *ClientWithResponses) DeleteAccountKeyWithResponse(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*DeleteAccountKeyResponse, error) {
+	rsp, err := c.DeleteAccountKey(ctx, siteId, accountKeyId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseDeleteAccountAccessKeyResponse(rsp)
+	return ParseDeleteAccountKeyResponse(rsp)
 }
 
-// ReadAccountAccessKeyWithResponse request returning *ReadAccountAccessKeyResponse
-func (c *ClientWithResponses) ReadAccountAccessKeyWithResponse(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*ReadAccountAccessKeyResponse, error) {
-	rsp, err := c.ReadAccountAccessKey(ctx, siteId, accountKeyId, reqEditors...)
+// GetAccountKeyWithResponse request returning *GetAccountKeyResponse
+func (c *ClientWithResponses) GetAccountKeyWithResponse(ctx context.Context, siteId string, accountKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*GetAccountKeyResponse, error) {
+	rsp, err := c.GetAccountKey(ctx, siteId, accountKeyId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseReadAccountAccessKeyResponse(rsp)
+	return ParseGetAccountKeyResponse(rsp)
 }
 
-// ListPermissionsWithResponse request returning *ListPermissionsResponse
-func (c *ClientWithResponses) ListPermissionsWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*ListPermissionsResponse, error) {
-	rsp, err := c.ListPermissions(ctx, siteId, reqEditors...)
+// GetPermissionsWithResponse request returning *GetPermissionsResponse
+func (c *ClientWithResponses) GetPermissionsWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*GetPermissionsResponse, error) {
+	rsp, err := c.GetPermissions(ctx, siteId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseListPermissionsResponse(rsp)
+	return ParseGetPermissionsResponse(rsp)
 }
 
 // CreatePermissionWithBodyWithResponse request with arbitrary body returning *CreatePermissionResponse
@@ -2363,13 +2363,13 @@ func (c *ClientWithResponses) DeletePermissionWithResponse(ctx context.Context, 
 	return ParseDeletePermissionResponse(rsp)
 }
 
-// ReadPermissionWithResponse request returning *ReadPermissionResponse
-func (c *ClientWithResponses) ReadPermissionWithResponse(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*ReadPermissionResponse, error) {
-	rsp, err := c.ReadPermission(ctx, siteId, permissionId, reqEditors...)
+// GetPermissionWithResponse request returning *GetPermissionResponse
+func (c *ClientWithResponses) GetPermissionWithResponse(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*GetPermissionResponse, error) {
+	rsp, err := c.GetPermission(ctx, siteId, permissionId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseReadPermissionResponse(rsp)
+	return ParseGetPermissionResponse(rsp)
 }
 
 // UpdatePermissionWithBodyWithResponse request with arbitrary body returning *UpdatePermissionResponse
@@ -2389,49 +2389,49 @@ func (c *ClientWithResponses) UpdatePermissionWithResponse(ctx context.Context, 
 	return ParseUpdatePermissionResponse(rsp)
 }
 
-// ListPermissionAccessKeysWithResponse request returning *ListPermissionAccessKeysResponse
-func (c *ClientWithResponses) ListPermissionAccessKeysWithResponse(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*ListPermissionAccessKeysResponse, error) {
-	rsp, err := c.ListPermissionAccessKeys(ctx, siteId, permissionId, reqEditors...)
+// GetPermissionKeysWithResponse request returning *GetPermissionKeysResponse
+func (c *ClientWithResponses) GetPermissionKeysWithResponse(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*GetPermissionKeysResponse, error) {
+	rsp, err := c.GetPermissionKeys(ctx, siteId, permissionId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseListPermissionAccessKeysResponse(rsp)
+	return ParseGetPermissionKeysResponse(rsp)
 }
 
-// CreatePermissionAccessKeyWithResponse request returning *CreatePermissionAccessKeyResponse
-func (c *ClientWithResponses) CreatePermissionAccessKeyWithResponse(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*CreatePermissionAccessKeyResponse, error) {
-	rsp, err := c.CreatePermissionAccessKey(ctx, siteId, permissionId, reqEditors...)
+// CreatePermissionKeyWithResponse request returning *CreatePermissionKeyResponse
+func (c *ClientWithResponses) CreatePermissionKeyWithResponse(ctx context.Context, siteId string, permissionId PermissionID, reqEditors ...RequestEditorFn) (*CreatePermissionKeyResponse, error) {
+	rsp, err := c.CreatePermissionKey(ctx, siteId, permissionId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseCreatePermissionAccessKeyResponse(rsp)
+	return ParseCreatePermissionKeyResponse(rsp)
 }
 
-// DeletePermissionAccessKeyWithResponse request returning *DeletePermissionAccessKeyResponse
-func (c *ClientWithResponses) DeletePermissionAccessKeyWithResponse(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*DeletePermissionAccessKeyResponse, error) {
-	rsp, err := c.DeletePermissionAccessKey(ctx, siteId, permissionId, permissionKeyId, reqEditors...)
+// DeletePermissionKeyWithResponse request returning *DeletePermissionKeyResponse
+func (c *ClientWithResponses) DeletePermissionKeyWithResponse(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*DeletePermissionKeyResponse, error) {
+	rsp, err := c.DeletePermissionKey(ctx, siteId, permissionId, permissionKeyId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseDeletePermissionAccessKeyResponse(rsp)
+	return ParseDeletePermissionKeyResponse(rsp)
 }
 
-// ReadPermissionAccessKeyWithResponse request returning *ReadPermissionAccessKeyResponse
-func (c *ClientWithResponses) ReadPermissionAccessKeyWithResponse(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*ReadPermissionAccessKeyResponse, error) {
-	rsp, err := c.ReadPermissionAccessKey(ctx, siteId, permissionId, permissionKeyId, reqEditors...)
+// GetPermissionKeyWithResponse request returning *GetPermissionKeyResponse
+func (c *ClientWithResponses) GetPermissionKeyWithResponse(ctx context.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID, reqEditors ...RequestEditorFn) (*GetPermissionKeyResponse, error) {
+	rsp, err := c.GetPermissionKey(ctx, siteId, permissionId, permissionKeyId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseReadPermissionAccessKeyResponse(rsp)
+	return ParseGetPermissionKeyResponse(rsp)
 }
 
-// ReadSiteStatusWithResponse request returning *ReadSiteStatusResponse
-func (c *ClientWithResponses) ReadSiteStatusWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*ReadSiteStatusResponse, error) {
-	rsp, err := c.ReadSiteStatus(ctx, siteId, reqEditors...)
+// GetStatusWithResponse request returning *GetStatusResponse
+func (c *ClientWithResponses) GetStatusWithResponse(ctx context.Context, siteId string, reqEditors ...RequestEditorFn) (*GetStatusResponse, error) {
+	rsp, err := c.GetStatus(ctx, siteId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseReadSiteStatusResponse(rsp)
+	return ParseGetStatusResponse(rsp)
 }
 
 // ParseDeleteBucketResponse parses an HTTP response from a DeleteBucketWithResponse call
@@ -2514,15 +2514,15 @@ func ParseCreateBucketResponse(rsp *http.Response) (*CreateBucketResponse, error
 	return response, nil
 }
 
-// ParseListClustersResponse parses an HTTP response from a ListClustersWithResponse call
-func ParseListClustersResponse(rsp *http.Response) (*ListClustersResponse, error) {
+// ParseGetClustersResponse parses an HTTP response from a GetClustersWithResponse call
+func ParseGetClustersResponse(rsp *http.Response) (*GetClustersResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListClustersResponse{
+	response := &GetClustersResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -2547,15 +2547,15 @@ func ParseListClustersResponse(rsp *http.Response) (*ListClustersResponse, error
 	return response, nil
 }
 
-// ParseReadClusterResponse parses an HTTP response from a ReadClusterWithResponse call
-func ParseReadClusterResponse(rsp *http.Response) (*ReadClusterResponse, error) {
+// ParseGetClusterResponse parses an HTTP response from a GetClusterWithResponse call
+func ParseGetClusterResponse(rsp *http.Response) (*GetClusterResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ReadClusterResponse{
+	response := &GetClusterResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -2587,15 +2587,15 @@ func ParseReadClusterResponse(rsp *http.Response) (*ReadClusterResponse, error) 
 	return response, nil
 }
 
-// ParseDeleteSiteAccountResponse parses an HTTP response from a DeleteSiteAccountWithResponse call
-func ParseDeleteSiteAccountResponse(rsp *http.Response) (*DeleteSiteAccountResponse, error) {
+// ParseDeleteAccountResponse parses an HTTP response from a DeleteAccountWithResponse call
+func ParseDeleteAccountResponse(rsp *http.Response) (*DeleteAccountResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &DeleteSiteAccountResponse{
+	response := &DeleteAccountResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -2620,15 +2620,15 @@ func ParseDeleteSiteAccountResponse(rsp *http.Response) (*DeleteSiteAccountRespo
 	return response, nil
 }
 
-// ParseReadSiteAccountResponse parses an HTTP response from a ReadSiteAccountWithResponse call
-func ParseReadSiteAccountResponse(rsp *http.Response) (*ReadSiteAccountResponse, error) {
+// ParseGetAccountResponse parses an HTTP response from a GetAccountWithResponse call
+func ParseGetAccountResponse(rsp *http.Response) (*GetAccountResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ReadSiteAccountResponse{
+	response := &GetAccountResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -2667,15 +2667,15 @@ func ParseReadSiteAccountResponse(rsp *http.Response) (*ReadSiteAccountResponse,
 	return response, nil
 }
 
-// ParseCreateSiteAccountResponse parses an HTTP response from a CreateSiteAccountWithResponse call
-func ParseCreateSiteAccountResponse(rsp *http.Response) (*CreateSiteAccountResponse, error) {
+// ParseCreateAccountResponse parses an HTTP response from a CreateAccountWithResponse call
+func ParseCreateAccountResponse(rsp *http.Response) (*CreateAccountResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &CreateSiteAccountResponse{
+	response := &CreateAccountResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -2721,15 +2721,15 @@ func ParseCreateSiteAccountResponse(rsp *http.Response) (*CreateSiteAccountRespo
 	return response, nil
 }
 
-// ParseListAccountAccessKeysResponse parses an HTTP response from a ListAccountAccessKeysWithResponse call
-func ParseListAccountAccessKeysResponse(rsp *http.Response) (*ListAccountAccessKeysResponse, error) {
+// ParseGetAccountKeysResponse parses an HTTP response from a GetAccountKeysWithResponse call
+func ParseGetAccountKeysResponse(rsp *http.Response) (*GetAccountKeysResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListAccountAccessKeysResponse{
+	response := &GetAccountKeysResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -2768,15 +2768,15 @@ func ParseListAccountAccessKeysResponse(rsp *http.Response) (*ListAccountAccessK
 	return response, nil
 }
 
-// ParseCreateAccountAccessKeyResponse parses an HTTP response from a CreateAccountAccessKeyWithResponse call
-func ParseCreateAccountAccessKeyResponse(rsp *http.Response) (*CreateAccountAccessKeyResponse, error) {
+// ParseCreateAccountKeyResponse parses an HTTP response from a CreateAccountKeyWithResponse call
+func ParseCreateAccountKeyResponse(rsp *http.Response) (*CreateAccountKeyResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &CreateAccountAccessKeyResponse{
+	response := &CreateAccountKeyResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -2822,15 +2822,15 @@ func ParseCreateAccountAccessKeyResponse(rsp *http.Response) (*CreateAccountAcce
 	return response, nil
 }
 
-// ParseDeleteAccountAccessKeyResponse parses an HTTP response from a DeleteAccountAccessKeyWithResponse call
-func ParseDeleteAccountAccessKeyResponse(rsp *http.Response) (*DeleteAccountAccessKeyResponse, error) {
+// ParseDeleteAccountKeyResponse parses an HTTP response from a DeleteAccountKeyWithResponse call
+func ParseDeleteAccountKeyResponse(rsp *http.Response) (*DeleteAccountKeyResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &DeleteAccountAccessKeyResponse{
+	response := &DeleteAccountKeyResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -2848,15 +2848,15 @@ func ParseDeleteAccountAccessKeyResponse(rsp *http.Response) (*DeleteAccountAcce
 	return response, nil
 }
 
-// ParseReadAccountAccessKeyResponse parses an HTTP response from a ReadAccountAccessKeyWithResponse call
-func ParseReadAccountAccessKeyResponse(rsp *http.Response) (*ReadAccountAccessKeyResponse, error) {
+// ParseGetAccountKeyResponse parses an HTTP response from a GetAccountKeyWithResponse call
+func ParseGetAccountKeyResponse(rsp *http.Response) (*GetAccountKeyResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ReadAccountAccessKeyResponse{
+	response := &GetAccountKeyResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -2895,15 +2895,15 @@ func ParseReadAccountAccessKeyResponse(rsp *http.Response) (*ReadAccountAccessKe
 	return response, nil
 }
 
-// ParseListPermissionsResponse parses an HTTP response from a ListPermissionsWithResponse call
-func ParseListPermissionsResponse(rsp *http.Response) (*ListPermissionsResponse, error) {
+// ParseGetPermissionsResponse parses an HTTP response from a GetPermissionsWithResponse call
+func ParseGetPermissionsResponse(rsp *http.Response) (*GetPermissionsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListPermissionsResponse{
+	response := &GetPermissionsResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -3015,15 +3015,15 @@ func ParseDeletePermissionResponse(rsp *http.Response) (*DeletePermissionRespons
 	return response, nil
 }
 
-// ParseReadPermissionResponse parses an HTTP response from a ReadPermissionWithResponse call
-func ParseReadPermissionResponse(rsp *http.Response) (*ReadPermissionResponse, error) {
+// ParseGetPermissionResponse parses an HTTP response from a GetPermissionWithResponse call
+func ParseGetPermissionResponse(rsp *http.Response) (*GetPermissionResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ReadPermissionResponse{
+	response := &GetPermissionResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -3116,15 +3116,15 @@ func ParseUpdatePermissionResponse(rsp *http.Response) (*UpdatePermissionRespons
 	return response, nil
 }
 
-// ParseListPermissionAccessKeysResponse parses an HTTP response from a ListPermissionAccessKeysWithResponse call
-func ParseListPermissionAccessKeysResponse(rsp *http.Response) (*ListPermissionAccessKeysResponse, error) {
+// ParseGetPermissionKeysResponse parses an HTTP response from a GetPermissionKeysWithResponse call
+func ParseGetPermissionKeysResponse(rsp *http.Response) (*GetPermissionKeysResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ListPermissionAccessKeysResponse{
+	response := &GetPermissionKeysResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -3163,15 +3163,15 @@ func ParseListPermissionAccessKeysResponse(rsp *http.Response) (*ListPermissionA
 	return response, nil
 }
 
-// ParseCreatePermissionAccessKeyResponse parses an HTTP response from a CreatePermissionAccessKeyWithResponse call
-func ParseCreatePermissionAccessKeyResponse(rsp *http.Response) (*CreatePermissionAccessKeyResponse, error) {
+// ParseCreatePermissionKeyResponse parses an HTTP response from a CreatePermissionKeyWithResponse call
+func ParseCreatePermissionKeyResponse(rsp *http.Response) (*CreatePermissionKeyResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &CreatePermissionAccessKeyResponse{
+	response := &CreatePermissionKeyResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -3217,15 +3217,15 @@ func ParseCreatePermissionAccessKeyResponse(rsp *http.Response) (*CreatePermissi
 	return response, nil
 }
 
-// ParseDeletePermissionAccessKeyResponse parses an HTTP response from a DeletePermissionAccessKeyWithResponse call
-func ParseDeletePermissionAccessKeyResponse(rsp *http.Response) (*DeletePermissionAccessKeyResponse, error) {
+// ParseDeletePermissionKeyResponse parses an HTTP response from a DeletePermissionKeyWithResponse call
+func ParseDeletePermissionKeyResponse(rsp *http.Response) (*DeletePermissionKeyResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &DeletePermissionAccessKeyResponse{
+	response := &DeletePermissionKeyResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -3250,15 +3250,15 @@ func ParseDeletePermissionAccessKeyResponse(rsp *http.Response) (*DeletePermissi
 	return response, nil
 }
 
-// ParseReadPermissionAccessKeyResponse parses an HTTP response from a ReadPermissionAccessKeyWithResponse call
-func ParseReadPermissionAccessKeyResponse(rsp *http.Response) (*ReadPermissionAccessKeyResponse, error) {
+// ParseGetPermissionKeyResponse parses an HTTP response from a GetPermissionKeyWithResponse call
+func ParseGetPermissionKeyResponse(rsp *http.Response) (*GetPermissionKeyResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ReadPermissionAccessKeyResponse{
+	response := &GetPermissionKeyResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -3297,15 +3297,15 @@ func ParseReadPermissionAccessKeyResponse(rsp *http.Response) (*ReadPermissionAc
 	return response, nil
 }
 
-// ParseReadSiteStatusResponse parses an HTTP response from a ReadSiteStatusWithResponse call
-func ParseReadSiteStatusResponse(rsp *http.Response) (*ReadSiteStatusResponse, error) {
+// ParseGetStatusResponse parses an HTTP response from a GetStatusWithResponse call
+func ParseGetStatusResponse(rsp *http.Response) (*GetStatusResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ReadSiteStatusResponse{
+	response := &GetStatusResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/apis/v1/zz_server_gen.go
+++ b/apis/v1/zz_server_gen.go
@@ -35,34 +35,34 @@ type ServerInterface interface {
 	CreateBucket(c *gin.Context, bucketName BucketName)
 	// サイト一覧の取得
 	// (GET /fed/v1/clusters)
-	ListClusters(c *gin.Context)
+	GetClusters(c *gin.Context)
 	// サイトの取得
 	// (GET /fed/v1/clusters/{site_id})
-	ReadCluster(c *gin.Context, siteId string)
+	GetCluster(c *gin.Context, siteId string)
 	// サイトアカウントの削除
 	// (DELETE /{site_id}/v2/account)
-	DeleteSiteAccount(c *gin.Context, siteId string)
+	DeleteAccount(c *gin.Context, siteId string)
 	// サイトアカウントの取得
 	// (GET /{site_id}/v2/account)
-	ReadSiteAccount(c *gin.Context, siteId string)
+	GetAccount(c *gin.Context, siteId string)
 	// サイトアカウントの作成
 	// (POST /{site_id}/v2/account)
-	CreateSiteAccount(c *gin.Context, siteId string)
+	CreateAccount(c *gin.Context, siteId string)
 	// サイトアカウントのアクセスキーの取得
 	// (GET /{site_id}/v2/account/keys)
-	ListAccountAccessKeys(c *gin.Context, siteId string)
+	GetAccountKeys(c *gin.Context, siteId string)
 	// サイトアカウントのアクセスキーの発行
 	// (POST /{site_id}/v2/account/keys)
-	CreateAccountAccessKey(c *gin.Context, siteId string)
+	CreateAccountKey(c *gin.Context, siteId string)
 	// サイトアカウントのアクセスキーの削除
 	// (DELETE /{site_id}/v2/account/keys/{account_key_id})
-	DeleteAccountAccessKey(c *gin.Context, siteId string, accountKeyId AccessKeyID)
+	DeleteAccountKey(c *gin.Context, siteId string, accountKeyId AccessKeyID)
 	// サイトアカウントのアクセスキーの取得
 	// (GET /{site_id}/v2/account/keys/{account_key_id})
-	ReadAccountAccessKey(c *gin.Context, siteId string, accountKeyId AccessKeyID)
+	GetAccountKey(c *gin.Context, siteId string, accountKeyId AccessKeyID)
 	// パーミッション一覧の取得
 	// (GET /{site_id}/v2/permissions)
-	ListPermissions(c *gin.Context, siteId string)
+	GetPermissions(c *gin.Context, siteId string)
 	// パーミッションの作成
 	// (POST /{site_id}/v2/permissions)
 	CreatePermission(c *gin.Context, siteId string)
@@ -71,25 +71,25 @@ type ServerInterface interface {
 	DeletePermission(c *gin.Context, siteId string, permissionId PermissionID)
 	// パーミッションの取得
 	// (GET /{site_id}/v2/permissions/{permission_id})
-	ReadPermission(c *gin.Context, siteId string, permissionId PermissionID)
+	GetPermission(c *gin.Context, siteId string, permissionId PermissionID)
 	// パーミッションの更新
 	// (PUT /{site_id}/v2/permissions/{permission_id})
 	UpdatePermission(c *gin.Context, siteId string, permissionId PermissionID)
 	// パーミッションが保有するアクセスキー一覧の取得
 	// (GET /{site_id}/v2/permissions/{permission_id}/keys)
-	ListPermissionAccessKeys(c *gin.Context, siteId string, permissionId PermissionID)
+	GetPermissionKeys(c *gin.Context, siteId string, permissionId PermissionID)
 	// パーミッションのアクセスキーの発行
 	// (POST /{site_id}/v2/permissions/{permission_id}/keys)
-	CreatePermissionAccessKey(c *gin.Context, siteId string, permissionId PermissionID)
+	CreatePermissionKey(c *gin.Context, siteId string, permissionId PermissionID)
 	// パーミッションが保有するアクセスキーの削除
 	// (DELETE /{site_id}/v2/permissions/{permission_id}/keys/{permission_key_id})
-	DeletePermissionAccessKey(c *gin.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID)
+	DeletePermissionKey(c *gin.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID)
 	// パーミッションが保有するアクセスキーの取得
 	// (GET /{site_id}/v2/permissions/{permission_id}/keys/{permission_key_id})
-	ReadPermissionAccessKey(c *gin.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID)
+	GetPermissionKey(c *gin.Context, siteId string, permissionId PermissionID, permissionKeyId AccessKeyID)
 	// サイトのステータスの取得
 	// (GET /{site_id}/v2/status)
-	ReadSiteStatus(c *gin.Context, siteId string)
+	GetStatus(c *gin.Context, siteId string)
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -142,18 +142,18 @@ func (siw *ServerInterfaceWrapper) CreateBucket(c *gin.Context) {
 	siw.Handler.CreateBucket(c, bucketName)
 }
 
-// ListClusters operation middleware
-func (siw *ServerInterfaceWrapper) ListClusters(c *gin.Context) {
+// GetClusters operation middleware
+func (siw *ServerInterfaceWrapper) GetClusters(c *gin.Context) {
 
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
 
-	siw.Handler.ListClusters(c)
+	siw.Handler.GetClusters(c)
 }
 
-// ReadCluster operation middleware
-func (siw *ServerInterfaceWrapper) ReadCluster(c *gin.Context) {
+// GetCluster operation middleware
+func (siw *ServerInterfaceWrapper) GetCluster(c *gin.Context) {
 
 	var err error
 
@@ -170,11 +170,11 @@ func (siw *ServerInterfaceWrapper) ReadCluster(c *gin.Context) {
 		middleware(c)
 	}
 
-	siw.Handler.ReadCluster(c, siteId)
+	siw.Handler.GetCluster(c, siteId)
 }
 
-// DeleteSiteAccount operation middleware
-func (siw *ServerInterfaceWrapper) DeleteSiteAccount(c *gin.Context) {
+// DeleteAccount operation middleware
+func (siw *ServerInterfaceWrapper) DeleteAccount(c *gin.Context) {
 
 	var err error
 
@@ -191,11 +191,11 @@ func (siw *ServerInterfaceWrapper) DeleteSiteAccount(c *gin.Context) {
 		middleware(c)
 	}
 
-	siw.Handler.DeleteSiteAccount(c, siteId)
+	siw.Handler.DeleteAccount(c, siteId)
 }
 
-// ReadSiteAccount operation middleware
-func (siw *ServerInterfaceWrapper) ReadSiteAccount(c *gin.Context) {
+// GetAccount operation middleware
+func (siw *ServerInterfaceWrapper) GetAccount(c *gin.Context) {
 
 	var err error
 
@@ -212,11 +212,11 @@ func (siw *ServerInterfaceWrapper) ReadSiteAccount(c *gin.Context) {
 		middleware(c)
 	}
 
-	siw.Handler.ReadSiteAccount(c, siteId)
+	siw.Handler.GetAccount(c, siteId)
 }
 
-// CreateSiteAccount operation middleware
-func (siw *ServerInterfaceWrapper) CreateSiteAccount(c *gin.Context) {
+// CreateAccount operation middleware
+func (siw *ServerInterfaceWrapper) CreateAccount(c *gin.Context) {
 
 	var err error
 
@@ -233,11 +233,11 @@ func (siw *ServerInterfaceWrapper) CreateSiteAccount(c *gin.Context) {
 		middleware(c)
 	}
 
-	siw.Handler.CreateSiteAccount(c, siteId)
+	siw.Handler.CreateAccount(c, siteId)
 }
 
-// ListAccountAccessKeys operation middleware
-func (siw *ServerInterfaceWrapper) ListAccountAccessKeys(c *gin.Context) {
+// GetAccountKeys operation middleware
+func (siw *ServerInterfaceWrapper) GetAccountKeys(c *gin.Context) {
 
 	var err error
 
@@ -254,11 +254,11 @@ func (siw *ServerInterfaceWrapper) ListAccountAccessKeys(c *gin.Context) {
 		middleware(c)
 	}
 
-	siw.Handler.ListAccountAccessKeys(c, siteId)
+	siw.Handler.GetAccountKeys(c, siteId)
 }
 
-// CreateAccountAccessKey operation middleware
-func (siw *ServerInterfaceWrapper) CreateAccountAccessKey(c *gin.Context) {
+// CreateAccountKey operation middleware
+func (siw *ServerInterfaceWrapper) CreateAccountKey(c *gin.Context) {
 
 	var err error
 
@@ -275,41 +275,11 @@ func (siw *ServerInterfaceWrapper) CreateAccountAccessKey(c *gin.Context) {
 		middleware(c)
 	}
 
-	siw.Handler.CreateAccountAccessKey(c, siteId)
+	siw.Handler.CreateAccountKey(c, siteId)
 }
 
-// DeleteAccountAccessKey operation middleware
-func (siw *ServerInterfaceWrapper) DeleteAccountAccessKey(c *gin.Context) {
-
-	var err error
-
-	// ------------- Path parameter "site_id" -------------
-	var siteId string
-
-	err = runtime.BindStyledParameter("simple", false, "site_id", c.Param("site_id"), &siteId)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"msg": fmt.Sprintf("Invalid format for parameter site_id: %s", err)})
-		return
-	}
-
-	// ------------- Path parameter "account_key_id" -------------
-	var accountKeyId AccessKeyID
-
-	err = runtime.BindStyledParameter("simple", false, "account_key_id", c.Param("account_key_id"), &accountKeyId)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"msg": fmt.Sprintf("Invalid format for parameter account_key_id: %s", err)})
-		return
-	}
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		middleware(c)
-	}
-
-	siw.Handler.DeleteAccountAccessKey(c, siteId, accountKeyId)
-}
-
-// ReadAccountAccessKey operation middleware
-func (siw *ServerInterfaceWrapper) ReadAccountAccessKey(c *gin.Context) {
+// DeleteAccountKey operation middleware
+func (siw *ServerInterfaceWrapper) DeleteAccountKey(c *gin.Context) {
 
 	var err error
 
@@ -335,11 +305,41 @@ func (siw *ServerInterfaceWrapper) ReadAccountAccessKey(c *gin.Context) {
 		middleware(c)
 	}
 
-	siw.Handler.ReadAccountAccessKey(c, siteId, accountKeyId)
+	siw.Handler.DeleteAccountKey(c, siteId, accountKeyId)
 }
 
-// ListPermissions operation middleware
-func (siw *ServerInterfaceWrapper) ListPermissions(c *gin.Context) {
+// GetAccountKey operation middleware
+func (siw *ServerInterfaceWrapper) GetAccountKey(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "site_id" -------------
+	var siteId string
+
+	err = runtime.BindStyledParameter("simple", false, "site_id", c.Param("site_id"), &siteId)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"msg": fmt.Sprintf("Invalid format for parameter site_id: %s", err)})
+		return
+	}
+
+	// ------------- Path parameter "account_key_id" -------------
+	var accountKeyId AccessKeyID
+
+	err = runtime.BindStyledParameter("simple", false, "account_key_id", c.Param("account_key_id"), &accountKeyId)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"msg": fmt.Sprintf("Invalid format for parameter account_key_id: %s", err)})
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+	}
+
+	siw.Handler.GetAccountKey(c, siteId, accountKeyId)
+}
+
+// GetPermissions operation middleware
+func (siw *ServerInterfaceWrapper) GetPermissions(c *gin.Context) {
 
 	var err error
 
@@ -356,7 +356,7 @@ func (siw *ServerInterfaceWrapper) ListPermissions(c *gin.Context) {
 		middleware(c)
 	}
 
-	siw.Handler.ListPermissions(c, siteId)
+	siw.Handler.GetPermissions(c, siteId)
 }
 
 // CreatePermission operation middleware
@@ -410,8 +410,8 @@ func (siw *ServerInterfaceWrapper) DeletePermission(c *gin.Context) {
 	siw.Handler.DeletePermission(c, siteId, permissionId)
 }
 
-// ReadPermission operation middleware
-func (siw *ServerInterfaceWrapper) ReadPermission(c *gin.Context) {
+// GetPermission operation middleware
+func (siw *ServerInterfaceWrapper) GetPermission(c *gin.Context) {
 
 	var err error
 
@@ -437,7 +437,7 @@ func (siw *ServerInterfaceWrapper) ReadPermission(c *gin.Context) {
 		middleware(c)
 	}
 
-	siw.Handler.ReadPermission(c, siteId, permissionId)
+	siw.Handler.GetPermission(c, siteId, permissionId)
 }
 
 // UpdatePermission operation middleware
@@ -470,8 +470,8 @@ func (siw *ServerInterfaceWrapper) UpdatePermission(c *gin.Context) {
 	siw.Handler.UpdatePermission(c, siteId, permissionId)
 }
 
-// ListPermissionAccessKeys operation middleware
-func (siw *ServerInterfaceWrapper) ListPermissionAccessKeys(c *gin.Context) {
+// GetPermissionKeys operation middleware
+func (siw *ServerInterfaceWrapper) GetPermissionKeys(c *gin.Context) {
 
 	var err error
 
@@ -497,11 +497,11 @@ func (siw *ServerInterfaceWrapper) ListPermissionAccessKeys(c *gin.Context) {
 		middleware(c)
 	}
 
-	siw.Handler.ListPermissionAccessKeys(c, siteId, permissionId)
+	siw.Handler.GetPermissionKeys(c, siteId, permissionId)
 }
 
-// CreatePermissionAccessKey operation middleware
-func (siw *ServerInterfaceWrapper) CreatePermissionAccessKey(c *gin.Context) {
+// CreatePermissionKey operation middleware
+func (siw *ServerInterfaceWrapper) CreatePermissionKey(c *gin.Context) {
 
 	var err error
 
@@ -527,50 +527,11 @@ func (siw *ServerInterfaceWrapper) CreatePermissionAccessKey(c *gin.Context) {
 		middleware(c)
 	}
 
-	siw.Handler.CreatePermissionAccessKey(c, siteId, permissionId)
+	siw.Handler.CreatePermissionKey(c, siteId, permissionId)
 }
 
-// DeletePermissionAccessKey operation middleware
-func (siw *ServerInterfaceWrapper) DeletePermissionAccessKey(c *gin.Context) {
-
-	var err error
-
-	// ------------- Path parameter "site_id" -------------
-	var siteId string
-
-	err = runtime.BindStyledParameter("simple", false, "site_id", c.Param("site_id"), &siteId)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"msg": fmt.Sprintf("Invalid format for parameter site_id: %s", err)})
-		return
-	}
-
-	// ------------- Path parameter "permission_id" -------------
-	var permissionId PermissionID
-
-	err = runtime.BindStyledParameter("simple", false, "permission_id", c.Param("permission_id"), &permissionId)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"msg": fmt.Sprintf("Invalid format for parameter permission_id: %s", err)})
-		return
-	}
-
-	// ------------- Path parameter "permission_key_id" -------------
-	var permissionKeyId AccessKeyID
-
-	err = runtime.BindStyledParameter("simple", false, "permission_key_id", c.Param("permission_key_id"), &permissionKeyId)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"msg": fmt.Sprintf("Invalid format for parameter permission_key_id: %s", err)})
-		return
-	}
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		middleware(c)
-	}
-
-	siw.Handler.DeletePermissionAccessKey(c, siteId, permissionId, permissionKeyId)
-}
-
-// ReadPermissionAccessKey operation middleware
-func (siw *ServerInterfaceWrapper) ReadPermissionAccessKey(c *gin.Context) {
+// DeletePermissionKey operation middleware
+func (siw *ServerInterfaceWrapper) DeletePermissionKey(c *gin.Context) {
 
 	var err error
 
@@ -605,11 +566,50 @@ func (siw *ServerInterfaceWrapper) ReadPermissionAccessKey(c *gin.Context) {
 		middleware(c)
 	}
 
-	siw.Handler.ReadPermissionAccessKey(c, siteId, permissionId, permissionKeyId)
+	siw.Handler.DeletePermissionKey(c, siteId, permissionId, permissionKeyId)
 }
 
-// ReadSiteStatus operation middleware
-func (siw *ServerInterfaceWrapper) ReadSiteStatus(c *gin.Context) {
+// GetPermissionKey operation middleware
+func (siw *ServerInterfaceWrapper) GetPermissionKey(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "site_id" -------------
+	var siteId string
+
+	err = runtime.BindStyledParameter("simple", false, "site_id", c.Param("site_id"), &siteId)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"msg": fmt.Sprintf("Invalid format for parameter site_id: %s", err)})
+		return
+	}
+
+	// ------------- Path parameter "permission_id" -------------
+	var permissionId PermissionID
+
+	err = runtime.BindStyledParameter("simple", false, "permission_id", c.Param("permission_id"), &permissionId)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"msg": fmt.Sprintf("Invalid format for parameter permission_id: %s", err)})
+		return
+	}
+
+	// ------------- Path parameter "permission_key_id" -------------
+	var permissionKeyId AccessKeyID
+
+	err = runtime.BindStyledParameter("simple", false, "permission_key_id", c.Param("permission_key_id"), &permissionKeyId)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"msg": fmt.Sprintf("Invalid format for parameter permission_key_id: %s", err)})
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+	}
+
+	siw.Handler.GetPermissionKey(c, siteId, permissionId, permissionKeyId)
+}
+
+// GetStatus operation middleware
+func (siw *ServerInterfaceWrapper) GetStatus(c *gin.Context) {
 
 	var err error
 
@@ -626,7 +626,7 @@ func (siw *ServerInterfaceWrapper) ReadSiteStatus(c *gin.Context) {
 		middleware(c)
 	}
 
-	siw.Handler.ReadSiteStatus(c, siteId)
+	siw.Handler.GetStatus(c, siteId)
 }
 
 // GinServerOptions provides options for the Gin server.
@@ -651,43 +651,43 @@ func RegisterHandlersWithOptions(router *gin.Engine, si ServerInterface, options
 
 	router.PUT(options.BaseURL+"/fed/v1/buckets/:bucket_name", wrapper.CreateBucket)
 
-	router.GET(options.BaseURL+"/fed/v1/clusters", wrapper.ListClusters)
+	router.GET(options.BaseURL+"/fed/v1/clusters", wrapper.GetClusters)
 
-	router.GET(options.BaseURL+"/fed/v1/clusters/:site_id", wrapper.ReadCluster)
+	router.GET(options.BaseURL+"/fed/v1/clusters/:site_id", wrapper.GetCluster)
 
-	router.DELETE(options.BaseURL+"/:site_id/v2/account", wrapper.DeleteSiteAccount)
+	router.DELETE(options.BaseURL+"/:site_id/v2/account", wrapper.DeleteAccount)
 
-	router.GET(options.BaseURL+"/:site_id/v2/account", wrapper.ReadSiteAccount)
+	router.GET(options.BaseURL+"/:site_id/v2/account", wrapper.GetAccount)
 
-	router.POST(options.BaseURL+"/:site_id/v2/account", wrapper.CreateSiteAccount)
+	router.POST(options.BaseURL+"/:site_id/v2/account", wrapper.CreateAccount)
 
-	router.GET(options.BaseURL+"/:site_id/v2/account/keys", wrapper.ListAccountAccessKeys)
+	router.GET(options.BaseURL+"/:site_id/v2/account/keys", wrapper.GetAccountKeys)
 
-	router.POST(options.BaseURL+"/:site_id/v2/account/keys", wrapper.CreateAccountAccessKey)
+	router.POST(options.BaseURL+"/:site_id/v2/account/keys", wrapper.CreateAccountKey)
 
-	router.DELETE(options.BaseURL+"/:site_id/v2/account/keys/:account_key_id", wrapper.DeleteAccountAccessKey)
+	router.DELETE(options.BaseURL+"/:site_id/v2/account/keys/:account_key_id", wrapper.DeleteAccountKey)
 
-	router.GET(options.BaseURL+"/:site_id/v2/account/keys/:account_key_id", wrapper.ReadAccountAccessKey)
+	router.GET(options.BaseURL+"/:site_id/v2/account/keys/:account_key_id", wrapper.GetAccountKey)
 
-	router.GET(options.BaseURL+"/:site_id/v2/permissions", wrapper.ListPermissions)
+	router.GET(options.BaseURL+"/:site_id/v2/permissions", wrapper.GetPermissions)
 
 	router.POST(options.BaseURL+"/:site_id/v2/permissions", wrapper.CreatePermission)
 
 	router.DELETE(options.BaseURL+"/:site_id/v2/permissions/:permission_id", wrapper.DeletePermission)
 
-	router.GET(options.BaseURL+"/:site_id/v2/permissions/:permission_id", wrapper.ReadPermission)
+	router.GET(options.BaseURL+"/:site_id/v2/permissions/:permission_id", wrapper.GetPermission)
 
 	router.PUT(options.BaseURL+"/:site_id/v2/permissions/:permission_id", wrapper.UpdatePermission)
 
-	router.GET(options.BaseURL+"/:site_id/v2/permissions/:permission_id/keys", wrapper.ListPermissionAccessKeys)
+	router.GET(options.BaseURL+"/:site_id/v2/permissions/:permission_id/keys", wrapper.GetPermissionKeys)
 
-	router.POST(options.BaseURL+"/:site_id/v2/permissions/:permission_id/keys", wrapper.CreatePermissionAccessKey)
+	router.POST(options.BaseURL+"/:site_id/v2/permissions/:permission_id/keys", wrapper.CreatePermissionKey)
 
-	router.DELETE(options.BaseURL+"/:site_id/v2/permissions/:permission_id/keys/:permission_key_id", wrapper.DeletePermissionAccessKey)
+	router.DELETE(options.BaseURL+"/:site_id/v2/permissions/:permission_id/keys/:permission_key_id", wrapper.DeletePermissionKey)
 
-	router.GET(options.BaseURL+"/:site_id/v2/permissions/:permission_id/keys/:permission_key_id", wrapper.ReadPermissionAccessKey)
+	router.GET(options.BaseURL+"/:site_id/v2/permissions/:permission_id/keys/:permission_key_id", wrapper.GetPermissionKey)
 
-	router.GET(options.BaseURL+"/:site_id/v2/status", wrapper.ReadSiteStatus)
+	router.GET(options.BaseURL+"/:site_id/v2/status", wrapper.GetStatus)
 
 	return router
 }

--- a/apis/v1/zz_types_gen.go
+++ b/apis/v1/zz_types_gen.go
@@ -107,14 +107,14 @@ type Cluster struct {
 	// URL of Control Panel
 	ControlPanelUrl string `json:"control_panel_url"`
 
-	// Display Name (en-us)
-	DislpayNameEnUs string `json:"dislpay_name_en_us"`
-
-	// Display Name (ja)
-	DislpayNameJa string `json:"dislpay_name_ja"`
-
 	// Display Name (Depending on Accept-Language)
 	DisplayName string `json:"display_name"`
+
+	// Display Name (en-us)
+	DisplayNameEnUs string `json:"display_name_en_us"`
+
+	// Display Name (ja)
+	DisplayNameJa string `json:"display_name_ja"`
 
 	// Display Order (Can be ignored)
 	DisplayOrder int `json:"display_order"`

--- a/example_fake_test.go
+++ b/example_fake_test.go
@@ -36,8 +36,8 @@ func initFakeServer() {
 					Id: siteId,
 
 					ControlPanelUrl: "https://secure.sakura.ad.jp/objectstorage/",
-					DislpayNameEnUs: "Ishikari Site #1",
-					DislpayNameJa:   "石狩第1サイト",
+					DisplayNameEnUs: "Ishikari Site #1",
+					DisplayNameJa:   "石狩第1サイト",
 					DisplayName:     "石狩第1サイト",
 					DisplayOrder:    1,
 					EndpointBase:    "isk01.sakurastorage.jp",

--- a/fake/account_keys_test.go
+++ b/fake/account_keys_test.go
@@ -30,8 +30,8 @@ func TestEngine_AccountKeys(t *testing.T) {
 				Id: siteId,
 
 				ControlPanelUrl: "https://secure.sakura.ad.jp/objectstorage/",
-				DislpayNameEnUs: "Ishikari Site #1",
-				DislpayNameJa:   "石狩第1サイト",
+				DisplayNameEnUs: "Ishikari Site #1",
+				DisplayNameJa:   "石狩第1サイト",
 				DisplayName:     "石狩第1サイト",
 				DisplayOrder:    1,
 				EndpointBase:    "isk01.sakurastorage.jp",

--- a/fake/accounts_test.go
+++ b/fake/accounts_test.go
@@ -29,8 +29,8 @@ func TestEngine_Accounts(t *testing.T) {
 				Id: siteId,
 
 				ControlPanelUrl: "https://secure.sakura.ad.jp/objectstorage/",
-				DislpayNameEnUs: "Ishikari Site #1",
-				DislpayNameJa:   "石狩第1サイト",
+				DisplayNameEnUs: "Ishikari Site #1",
+				DisplayNameJa:   "石狩第1サイト",
 				DisplayName:     "石狩第1サイト",
 				DisplayOrder:    1,
 				EndpointBase:    "isk01.sakurastorage.jp",

--- a/fake/buckets_test.go
+++ b/fake/buckets_test.go
@@ -28,8 +28,8 @@ func TestEngine_Buckets(t *testing.T) {
 				Id: "isk01",
 
 				ControlPanelUrl: "https://secure.sakura.ad.jp/objectstorage/",
-				DislpayNameEnUs: "Ishikari Site #1",
-				DislpayNameJa:   "石狩第1サイト",
+				DisplayNameEnUs: "Ishikari Site #1",
+				DisplayNameJa:   "石狩第1サイト",
 				DisplayName:     "石狩第1サイト",
 				DisplayOrder:    1,
 				EndpointBase:    "isk01.sakurastorage.jp",

--- a/fake/clusters_test.go
+++ b/fake/clusters_test.go
@@ -28,8 +28,8 @@ func TestEngine_Clusters(t *testing.T) {
 				Id: "isk01",
 
 				ControlPanelUrl: "https://secure.sakura.ad.jp/objectstorage/",
-				DislpayNameEnUs: "Ishikari Site #1",
-				DislpayNameJa:   "石狩第1サイト",
+				DisplayNameEnUs: "Ishikari Site #1",
+				DisplayNameJa:   "石狩第1サイト",
 				DisplayName:     "石狩第1サイト",
 				DisplayOrder:    1,
 				EndpointBase:    "isk01.sakurastorage.jp",

--- a/fake/permissions_test.go
+++ b/fake/permissions_test.go
@@ -30,8 +30,8 @@ func TestEngine_Permissions(t *testing.T) {
 				Id: siteId,
 
 				ControlPanelUrl: "https://secure.sakura.ad.jp/objectstorage/",
-				DislpayNameEnUs: "Ishikari Site #1",
-				DislpayNameJa:   "石狩第1サイト",
+				DisplayNameEnUs: "Ishikari Site #1",
+				DisplayNameJa:   "石狩第1サイト",
 				DisplayName:     "石狩第1サイト",
 				DisplayOrder:    1,
 				EndpointBase:    "isk01.sakurastorage.jp",

--- a/fake/server/account_keys.go
+++ b/fake/server/account_keys.go
@@ -23,7 +23,7 @@ import (
 
 // ListAccountAccessKeys サイトアカウントのアクセスキーの取得
 // (GET /{site_name}/v2/account/keys)
-func (s *Server) ListAccountAccessKeys(c *gin.Context, siteId string) {
+func (s *Server) GetAccountKeys(c *gin.Context, siteId string) {
 	keys, err := s.Engine.ListAccountAccessKeys(siteId)
 	if err != nil {
 		s.handleError(c, err)
@@ -37,7 +37,7 @@ func (s *Server) ListAccountAccessKeys(c *gin.Context, siteId string) {
 
 // CreateAccountAccessKey サイトアカウントのアクセスキーの発行
 // (POST /{site_name}/v2/account/keys)
-func (s *Server) CreateAccountAccessKey(c *gin.Context, siteId string) {
+func (s *Server) CreateAccountKey(c *gin.Context, siteId string) {
 	key, err := s.Engine.CreateAccountAccessKey(siteId)
 	if err != nil {
 		s.handleError(c, err)
@@ -51,7 +51,7 @@ func (s *Server) CreateAccountAccessKey(c *gin.Context, siteId string) {
 
 // DeleteAccountAccessKey サイトアカウントのアクセスキーの削除
 // (DELETE /{site_name}/v2/account/keys/{id})
-func (s *Server) DeleteAccountAccessKey(c *gin.Context, siteId string, accountKeyId v1.AccessKeyID) {
+func (s *Server) DeleteAccountKey(c *gin.Context, siteId string, accountKeyId v1.AccessKeyID) {
 	if err := s.Engine.DeleteAccountAccessKey(siteId, accountKeyId.String()); err != nil {
 		s.handleError(c, err)
 		return
@@ -62,7 +62,7 @@ func (s *Server) DeleteAccountAccessKey(c *gin.Context, siteId string, accountKe
 
 // ReadAccountAccessKey サイトアカウントのアクセスキーの取得
 // (GET /{site_name}/v2/account/keys/{id})
-func (s *Server) ReadAccountAccessKey(c *gin.Context, siteId string, accountKeyId v1.AccessKeyID) {
+func (s *Server) GetAccountKey(c *gin.Context, siteId string, accountKeyId v1.AccessKeyID) {
 	key, err := s.Engine.ReadAccountAccessKey(siteId, accountKeyId.String())
 	if err != nil {
 		s.handleError(c, err)

--- a/fake/server/accounts.go
+++ b/fake/server/accounts.go
@@ -23,7 +23,7 @@ import (
 
 // DeleteSiteAccount サイトアカウントの削除
 // (DELETE /{site_name}/v2/account)
-func (s *Server) DeleteSiteAccount(c *gin.Context, siteId string) {
+func (s *Server) DeleteAccount(c *gin.Context, siteId string) {
 	if err := s.Engine.DeleteSiteAccount(siteId); err != nil {
 		s.handleError(c, err)
 		return
@@ -34,7 +34,7 @@ func (s *Server) DeleteSiteAccount(c *gin.Context, siteId string) {
 
 // ReadSiteAccount サイトアカウントの取得
 // (GET /{site_name}/v2/account)
-func (s *Server) ReadSiteAccount(c *gin.Context, siteId string) {
+func (s *Server) GetAccount(c *gin.Context, siteId string) {
 	account, err := s.Engine.ReadSiteAccount(siteId)
 	if err != nil {
 		s.handleError(c, err)
@@ -48,7 +48,7 @@ func (s *Server) ReadSiteAccount(c *gin.Context, siteId string) {
 
 // CreateSiteAccount サイトアカウントの作成
 // (POST /{site_name}/v2/account)
-func (s *Server) CreateSiteAccount(c *gin.Context, siteId string) {
+func (s *Server) CreateAccount(c *gin.Context, siteId string) {
 	account, err := s.Engine.CreateSiteAccount(siteId)
 	if err != nil {
 		s.handleError(c, err)

--- a/fake/server/clusters.go
+++ b/fake/server/clusters.go
@@ -23,7 +23,7 @@ import (
 
 // ListClusters サイト一覧の取得
 // (GET /fed/v1/clusters)
-func (s *Server) ListClusters(c *gin.Context) {
+func (s *Server) GetClusters(c *gin.Context) {
 	clusters, err := s.Engine.ListClusters()
 	if err != nil {
 		s.handleError(c, err)
@@ -37,7 +37,7 @@ func (s *Server) ListClusters(c *gin.Context) {
 
 // ReadCluster サイトの取得
 // (GET /fed/v1/clusters/{id})
-func (s *Server) ReadCluster(c *gin.Context, siteId string) {
+func (s *Server) GetCluster(c *gin.Context, siteId string) {
 	cluster, err := s.Engine.ReadCluster(siteId)
 	if err != nil {
 		s.handleError(c, err)

--- a/fake/server/permission_keys.go
+++ b/fake/server/permission_keys.go
@@ -23,7 +23,7 @@ import (
 
 // ListPermissionAccessKeys パーミッションが保有するアクセスキー一覧の取得
 // (GET /{site_name}/v2/permissions/{id}/keys)
-func (s *Server) ListPermissionAccessKeys(c *gin.Context, siteId string, permissionId v1.PermissionID) {
+func (s *Server) GetPermissionKeys(c *gin.Context, siteId string, permissionId v1.PermissionID) {
 	keys, err := s.Engine.ListPermissionAccessKeys(siteId, permissionId.Int64())
 	if err != nil {
 		s.handleError(c, err)
@@ -37,7 +37,7 @@ func (s *Server) ListPermissionAccessKeys(c *gin.Context, siteId string, permiss
 
 // CreatePermissionAccessKey パーミッションのアクセスキーの発行
 // (POST /{site_name}/v2/permissions/{id}/keys)
-func (s *Server) CreatePermissionAccessKey(c *gin.Context, siteId string, permissionId v1.PermissionID) {
+func (s *Server) CreatePermissionKey(c *gin.Context, siteId string, permissionId v1.PermissionID) {
 	key, err := s.Engine.CreatePermissionAccessKey(siteId, permissionId.Int64())
 	if err != nil {
 		s.handleError(c, err)
@@ -51,7 +51,7 @@ func (s *Server) CreatePermissionAccessKey(c *gin.Context, siteId string, permis
 
 // DeletePermissionAccessKey パーミッションが保有するアクセスキーの削除
 // (DELETE /{site_name}/v2/permissions/{id}/keys/{key_id})
-func (s *Server) DeletePermissionAccessKey(c *gin.Context, siteId string, permissionId v1.PermissionID, permissionKeyId v1.AccessKeyID) {
+func (s *Server) DeletePermissionKey(c *gin.Context, siteId string, permissionId v1.PermissionID, permissionKeyId v1.AccessKeyID) {
 	if err := s.Engine.DeletePermissionAccessKey(siteId, permissionId.Int64(), permissionKeyId.String()); err != nil {
 		s.handleError(c, err)
 		return
@@ -62,7 +62,7 @@ func (s *Server) DeletePermissionAccessKey(c *gin.Context, siteId string, permis
 
 // ReadPermissionAccessKey パーミッションが保有するアクセスキーの取得
 // (GET /{site_name}/v2/permissions/{id}/keys/{key_id})
-func (s *Server) ReadPermissionAccessKey(c *gin.Context, siteId string, permissionId v1.PermissionID, permissionKeyId v1.AccessKeyID) {
+func (s *Server) GetPermissionKey(c *gin.Context, siteId string, permissionId v1.PermissionID, permissionKeyId v1.AccessKeyID) {
 	key, err := s.Engine.ReadPermissionAccessKey(siteId, permissionId.Int64(), permissionKeyId.String())
 	if err != nil {
 		s.handleError(c, err)

--- a/fake/server/permissions.go
+++ b/fake/server/permissions.go
@@ -23,7 +23,7 @@ import (
 
 // ListPermissions パーミッション一覧の取得
 // (GET /{site_name}/v2/permissions)
-func (s *Server) ListPermissions(c *gin.Context, siteId string) {
+func (s *Server) GetPermissions(c *gin.Context, siteId string) {
 	permissions, err := s.Engine.ListPermissions(siteId)
 	if err != nil {
 		s.handleError(c, err)
@@ -66,7 +66,7 @@ func (s *Server) DeletePermission(c *gin.Context, siteId string, permissionId v1
 
 // ReadPermission パーミッションの取得
 // (GET /{site_name}/v2/permissions/{id})
-func (s *Server) ReadPermission(c *gin.Context, siteId string, permissionId v1.PermissionID) {
+func (s *Server) GetPermission(c *gin.Context, siteId string, permissionId v1.PermissionID) {
 	permission, err := s.Engine.ReadPermission(siteId, permissionId.Int64())
 	if err != nil {
 		s.handleError(c, err)

--- a/fake/server/site_status.go
+++ b/fake/server/site_status.go
@@ -23,7 +23,7 @@ import (
 
 // ReadSiteStatus サイトのステータスの取得
 // (GET /{site_name}/v2/status)
-func (s *Server) ReadSiteStatus(c *gin.Context, siteId string) {
+func (s *Server) GetStatus(c *gin.Context, siteId string) {
 	status, err := s.Engine.ReadSiteStatus(siteId)
 	if err != nil {
 		s.handleError(c, err)

--- a/permissions.go
+++ b/permissions.go
@@ -41,7 +41,7 @@ type PermissionAPI interface {
 	// ReadAccessKey アクセスキーの参照
 	//
 	// Secretは常に空文字になっている
-	ReadAccessKey(ctx context.Context, siteId string, permissonId int64, accessKeyId string) (*v1.PermissionKey, error)
+	ReadAccessKey(ctx context.Context, siteId string, permissionId int64, accessKeyId string) (*v1.PermissionKey, error)
 	// DeleteAccessKey アクセスキーの削除
 	DeleteAccessKey(ctx context.Context, siteId string, permissionId int64, accessKeyId string) error
 }
@@ -58,7 +58,7 @@ func NewPermissionOp(client *Client) PermissionAPI {
 }
 
 func (op *permissionOp) List(ctx context.Context, siteId string) ([]*v1.Permission, error) {
-	resp, err := op.client.apiClient().ListPermissionsWithResponse(ctx, siteId)
+	resp, err := op.client.apiClient().GetPermissionsWithResponse(ctx, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (op *permissionOp) Create(ctx context.Context, siteId string, params *v1.Cr
 }
 
 func (op *permissionOp) Read(ctx context.Context, siteId string, permissionId int64) (*v1.Permission, error) {
-	resp, err := op.client.apiClient().ReadPermissionWithResponse(ctx, siteId, v1.PermissionID(permissionId))
+	resp, err := op.client.apiClient().GetPermissionWithResponse(ctx, siteId, v1.PermissionID(permissionId))
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (op *permissionOp) Delete(ctx context.Context, siteId string, permissionId 
 }
 
 func (op *permissionOp) ListAccessKeys(ctx context.Context, siteId string, permissionId int64) ([]*v1.PermissionKey, error) {
-	resp, err := op.client.apiClient().ListPermissionAccessKeysWithResponse(ctx, siteId, v1.PermissionID(permissionId))
+	resp, err := op.client.apiClient().GetPermissionKeysWithResponse(ctx, siteId, v1.PermissionID(permissionId))
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (op *permissionOp) ListAccessKeys(ctx context.Context, siteId string, permi
 }
 
 func (op *permissionOp) CreateAccessKey(ctx context.Context, siteId string, permissionId int64) (*v1.PermissionKey, error) {
-	resp, err := op.client.apiClient().CreatePermissionAccessKeyWithResponse(ctx, siteId, v1.PermissionID(permissionId))
+	resp, err := op.client.apiClient().CreatePermissionKeyWithResponse(ctx, siteId, v1.PermissionID(permissionId))
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func (op *permissionOp) CreateAccessKey(ctx context.Context, siteId string, perm
 }
 
 func (op *permissionOp) ReadAccessKey(ctx context.Context, siteId string, permissionId int64, accessKeyId string) (*v1.PermissionKey, error) {
-	resp, err := op.client.apiClient().ReadPermissionAccessKeyWithResponse(ctx, siteId,
+	resp, err := op.client.apiClient().GetPermissionKeyWithResponse(ctx, siteId,
 		v1.PermissionID(permissionId), v1.AccessKeyID(accessKeyId))
 	if err != nil {
 		return nil, err
@@ -160,7 +160,7 @@ func (op *permissionOp) ReadAccessKey(ctx context.Context, siteId string, permis
 }
 
 func (op *permissionOp) DeleteAccessKey(ctx context.Context, siteId string, permissionId int64, accessKeyId string) error {
-	resp, err := op.client.apiClient().DeletePermissionAccessKeyWithResponse(ctx, siteId,
+	resp, err := op.client.apiClient().DeletePermissionKeyWithResponse(ctx, siteId,
 		v1.PermissionID(permissionId), v1.AccessKeyID(accessKeyId))
 	if err != nil {
 		return err

--- a/site_status.go
+++ b/site_status.go
@@ -38,7 +38,7 @@ func NewSiteStatusOp(client *Client) SiteStatusAPI {
 }
 
 func (op *siteStatusOp) Read(ctx context.Context, siteId string) (*v1.Status, error) {
-	resp, err := op.client.apiClient().ReadSiteStatusWithResponse(ctx, siteId)
+	resp, err := op.client.apiClient().GetStatusWithResponse(ctx, siteId)
 	if err != nil {
 		return nil, err
 	}

--- a/sites.go
+++ b/sites.go
@@ -40,7 +40,7 @@ func NewSiteOp(client *Client) SiteAPI {
 }
 
 func (op *siteOp) List(ctx context.Context) ([]*v1.Cluster, error) {
-	resp, err := op.client.apiClient().ListClustersWithResponse(ctx)
+	resp, err := op.client.apiClient().GetClustersWithResponse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (op *siteOp) List(ctx context.Context) ([]*v1.Cluster, error) {
 }
 
 func (op *siteOp) Read(ctx context.Context, id string) (*v1.Cluster, error) {
-	resp, err := op.client.apiClient().ReadClusterWithResponse(ctx, id)
+	resp, err := op.client.apiClient().GetClusterWithResponse(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/version.go
+++ b/version.go
@@ -17,6 +17,6 @@ package objectstorage
 var (
 	// Version app version
 	Version = "v0.0.1"
-	// Revision git commit short commithash
+	// Revision git commit short commit hash
 	Revision = "xxxxxx" // set on build time
 )


### PR DESCRIPTION
アップストリームでのswagger.jsonの更新を反映する。

- infoを追加
- typo: dislpay -> displayに修正
- operationIdをオリジナルに合わせ修正
- patternの正規表現+exampleを修正
- 利用していないコンポーネントを除去(コメントアウトしていた部分)
- tagsの追加

Note: operationIdが付与されたが、object-storage-api-go側でラップしている部分のfunc名などは修正しない。