### PR TITLE
sacloud/api-client-goの導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,8 @@ import (
 )
 
 func main() {
-	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
-	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
-
-	client := &objectstorage.Client{
-		Token:      token,
-		Secret:     secret,
-	}
-	ctx := context.Background()
+    ctx := context.Background()
+    client := &objectstorage.Client{} // デフォルトでusacloud互換プロファイル or 環境変数(SAKURACLOUD_ACCESS_TOKEN{_SECRET})が利用される
 
 	// サイト一覧を取得
 	siteOp := objectstorage.NewSiteOp(client)

--- a/accounts.go
+++ b/accounts.go
@@ -53,7 +53,11 @@ func NewAccountOp(client *Client) AccountAPI {
 }
 
 func (op *accountOp) Create(ctx context.Context, siteId string) (*v1.Account, error) {
-	resp, err := op.client.apiClient().CreateAccountWithResponse(ctx, siteId)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.CreateAccountWithResponse(ctx, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +69,11 @@ func (op *accountOp) Create(ctx context.Context, siteId string) (*v1.Account, er
 }
 
 func (op *accountOp) Read(ctx context.Context, siteId string) (*v1.Account, error) {
-	resp, err := op.client.apiClient().GetAccountWithResponse(ctx, siteId)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.GetAccountWithResponse(ctx, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +85,11 @@ func (op *accountOp) Read(ctx context.Context, siteId string) (*v1.Account, erro
 }
 
 func (op *accountOp) Delete(ctx context.Context, siteId string) error {
-	resp, err := op.client.apiClient().DeleteAccountWithResponse(ctx, siteId)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return err
+	}
+	resp, err := apiClient.DeleteAccountWithResponse(ctx, siteId)
 	if err != nil {
 		return err
 	}
@@ -85,7 +97,11 @@ func (op *accountOp) Delete(ctx context.Context, siteId string) error {
 }
 
 func (op *accountOp) CreateAccessKey(ctx context.Context, siteId string) (*v1.AccountKey, error) {
-	resp, err := op.client.apiClient().CreateAccountKeyWithResponse(ctx, siteId)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.CreateAccountKeyWithResponse(ctx, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +113,11 @@ func (op *accountOp) CreateAccessKey(ctx context.Context, siteId string) (*v1.Ac
 }
 
 func (op *accountOp) ReadAccessKey(ctx context.Context, siteId, accessKeyId string) (*v1.AccountKey, error) {
-	resp, err := op.client.apiClient().GetAccountKeyWithResponse(ctx, siteId, v1.AccessKeyID(accessKeyId))
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.GetAccountKeyWithResponse(ctx, siteId, v1.AccessKeyID(accessKeyId))
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +129,11 @@ func (op *accountOp) ReadAccessKey(ctx context.Context, siteId, accessKeyId stri
 }
 
 func (op *accountOp) DeleteAccessKey(ctx context.Context, siteId, accessKeyId string) error {
-	resp, err := op.client.apiClient().DeleteAccountKeyWithResponse(ctx, siteId, v1.AccessKeyID(accessKeyId))
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return err
+	}
+	resp, err := apiClient.DeleteAccountKeyWithResponse(ctx, siteId, v1.AccessKeyID(accessKeyId))
 	if err != nil {
 		return err
 	}

--- a/buckets.go
+++ b/buckets.go
@@ -44,7 +44,11 @@ func (op *bucketOp) Create(ctx context.Context, siteId, bucketName string) (*v1.
 		ClusterId: siteId,
 	}
 
-	resp, err := op.client.apiClient().CreateBucketWithResponse(ctx, v1.BucketName(bucketName), params)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.CreateBucketWithResponse(ctx, v1.BucketName(bucketName), params)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +64,11 @@ func (op *bucketOp) Delete(ctx context.Context, siteId, bucketName string) error
 		ClusterId: siteId,
 	}
 
-	resp, err := op.client.apiClient().DeleteBucketWithResponse(ctx, v1.BucketName(bucketName), params)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return err
+	}
+	resp, err := apiClient.DeleteBucketWithResponse(ctx, v1.BucketName(bucketName), params)
 	if err != nil {
 		return err
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -17,7 +17,6 @@ package objectstorage_test
 import (
 	"context"
 	"fmt"
-	"os"
 
 	objectstorage "github.com/sacloud/object-storage-api-go"
 	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
@@ -29,12 +28,7 @@ var serverURL = defaultServerURL
 
 // Example_clusterAPI サイト(クラスタ)APIの利用例
 func Example_clusterAPI() {
-	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
-	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
-
 	client := &objectstorage.Client{
-		Token:      token,
-		Secret:     secret,
 		APIRootURL: serverURL, // 省略可能
 	}
 
@@ -52,12 +46,7 @@ func Example_clusterAPI() {
 
 // Example_bucketAPI バケットAPIの利用例
 func Example_bucketAPI() {
-	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
-	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
-
 	client := &objectstorage.Client{
-		Token:      token,
-		Secret:     secret,
 		APIRootURL: serverURL, // 省略可能
 	}
 	ctx := context.Background()
@@ -92,12 +81,7 @@ func Example_bucketAPI() {
 
 // Example_accountAPI アカウントAPIの利用例
 func Example_accountAPI() {
-	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
-	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
-
 	client := &objectstorage.Client{
-		Token:      token,
-		Secret:     secret,
 		APIRootURL: serverURL, // 省略可能
 	}
 	ctx := context.Background()
@@ -137,12 +121,7 @@ func Example_accountAPI() {
 
 // Example_permissionAPI パーミッションAPIの利用例
 func Example_permissionAPI() {
-	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
-	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
-
 	client := &objectstorage.Client{
-		Token:      token,
-		Secret:     secret,
 		APIRootURL: serverURL, // 省略可能
 	}
 	ctx := context.Background()
@@ -194,12 +173,7 @@ func Example_permissionAPI() {
 
 // Example_siteStatusAPI サイトステータスAPIの利用例
 func Example_siteStatusAPI() {
-	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
-	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
-
 	client := &objectstorage.Client{
-		Token:      token,
-		Secret:     secret,
 		APIRootURL: serverURL, // 省略可能
 	}
 	ctx := context.Background()

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/deepmap/oapi-codegen v1.9.1
 	github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a
 	github.com/gin-gonic/gin v1.7.4
-	github.com/hashicorp/go-retryablehttp v0.7.0
-	github.com/sacloud/go-http v0.0.4
+	github.com/sacloud/api-client-go v0.0.1
+	github.com/sacloud/sacloud-go/pkg v0.0.0-20220317060010-e514788840a8
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
 )
@@ -37,6 +37,7 @@ require (
 	github.com/go-playground/validator/v10 v10.9.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
@@ -44,6 +45,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sacloud/go-http v0.0.4 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/ugorji/go/codec v1.2.6 // indirect
 	go.uber.org/ratelimit v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -403,8 +403,13 @@ github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUA
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/sacloud/api-client-go v0.0.1 h1:adcDKnqTfg9FijU/lCygv3uniRlSFSfSkAK+LK7g1uk=
+github.com/sacloud/api-client-go v0.0.1/go.mod h1:RvP4b31YdaVjXM/XQAvKAeTTs0vGdvfypvP/7ysWdAA=
 github.com/sacloud/go-http v0.0.4 h1:+vgx/uCctcGiHMe8jE+qirMKd3+d73MNZXK7nrUo0po=
 github.com/sacloud/go-http v0.0.4/go.mod h1:aYTXNuAnPmD6Ar3ktDaR1gPxJCPv2CqpppcYciy1hmo=
+github.com/sacloud/sacloud-go/pkg v0.0.0-20220310002004-ab494c9c1c6d/go.mod h1:/hcfG/jZlqNDRpnMDl9rm1aBLgNCeX1NF6FyaIwk9+k=
+github.com/sacloud/sacloud-go/pkg v0.0.0-20220317060010-e514788840a8 h1:9kqQr7dky4+bQlI87ioElCy2p1WT4w1feDL13cf41Ks=
+github.com/sacloud/sacloud-go/pkg v0.0.0-20220317060010-e514788840a8/go.mod h1:/hcfG/jZlqNDRpnMDl9rm1aBLgNCeX1NF6FyaIwk9+k=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/permissions.go
+++ b/permissions.go
@@ -58,7 +58,11 @@ func NewPermissionOp(client *Client) PermissionAPI {
 }
 
 func (op *permissionOp) List(ctx context.Context, siteId string) ([]*v1.Permission, error) {
-	resp, err := op.client.apiClient().GetPermissionsWithResponse(ctx, siteId)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.GetPermissionsWithResponse(ctx, siteId)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +78,11 @@ func (op *permissionOp) List(ctx context.Context, siteId string) ([]*v1.Permissi
 }
 
 func (op *permissionOp) Create(ctx context.Context, siteId string, params *v1.CreatePermissionParams) (*v1.Permission, error) {
-	resp, err := op.client.apiClient().CreatePermissionWithResponse(ctx, siteId, v1.CreatePermissionJSONRequestBody(*params))
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.CreatePermissionWithResponse(ctx, siteId, v1.CreatePermissionJSONRequestBody(*params))
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +94,11 @@ func (op *permissionOp) Create(ctx context.Context, siteId string, params *v1.Cr
 }
 
 func (op *permissionOp) Read(ctx context.Context, siteId string, permissionId int64) (*v1.Permission, error) {
-	resp, err := op.client.apiClient().GetPermissionWithResponse(ctx, siteId, v1.PermissionID(permissionId))
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.GetPermissionWithResponse(ctx, siteId, v1.PermissionID(permissionId))
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +110,11 @@ func (op *permissionOp) Read(ctx context.Context, siteId string, permissionId in
 }
 
 func (op *permissionOp) Update(ctx context.Context, siteId string, permissionId int64, params *v1.UpdatePermissionParams) (*v1.Permission, error) {
-	resp, err := op.client.apiClient().UpdatePermissionWithResponse(ctx, siteId,
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.UpdatePermissionWithResponse(ctx, siteId,
 		v1.PermissionID(permissionId), v1.UpdatePermissionJSONRequestBody(*params))
 	if err != nil {
 		return nil, err
@@ -111,7 +127,11 @@ func (op *permissionOp) Update(ctx context.Context, siteId string, permissionId 
 }
 
 func (op *permissionOp) Delete(ctx context.Context, siteId string, permissionId int64) error {
-	resp, err := op.client.apiClient().DeletePermissionWithResponse(ctx, siteId, v1.PermissionID(permissionId))
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return err
+	}
+	resp, err := apiClient.DeletePermissionWithResponse(ctx, siteId, v1.PermissionID(permissionId))
 	if err != nil {
 		return err
 	}
@@ -119,7 +139,11 @@ func (op *permissionOp) Delete(ctx context.Context, siteId string, permissionId 
 }
 
 func (op *permissionOp) ListAccessKeys(ctx context.Context, siteId string, permissionId int64) ([]*v1.PermissionKey, error) {
-	resp, err := op.client.apiClient().GetPermissionKeysWithResponse(ctx, siteId, v1.PermissionID(permissionId))
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.GetPermissionKeysWithResponse(ctx, siteId, v1.PermissionID(permissionId))
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +159,11 @@ func (op *permissionOp) ListAccessKeys(ctx context.Context, siteId string, permi
 }
 
 func (op *permissionOp) CreateAccessKey(ctx context.Context, siteId string, permissionId int64) (*v1.PermissionKey, error) {
-	resp, err := op.client.apiClient().CreatePermissionKeyWithResponse(ctx, siteId, v1.PermissionID(permissionId))
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.CreatePermissionKeyWithResponse(ctx, siteId, v1.PermissionID(permissionId))
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +175,11 @@ func (op *permissionOp) CreateAccessKey(ctx context.Context, siteId string, perm
 }
 
 func (op *permissionOp) ReadAccessKey(ctx context.Context, siteId string, permissionId int64, accessKeyId string) (*v1.PermissionKey, error) {
-	resp, err := op.client.apiClient().GetPermissionKeyWithResponse(ctx, siteId,
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.GetPermissionKeyWithResponse(ctx, siteId,
 		v1.PermissionID(permissionId), v1.AccessKeyID(accessKeyId))
 	if err != nil {
 		return nil, err
@@ -160,7 +192,11 @@ func (op *permissionOp) ReadAccessKey(ctx context.Context, siteId string, permis
 }
 
 func (op *permissionOp) DeleteAccessKey(ctx context.Context, siteId string, permissionId int64, accessKeyId string) error {
-	resp, err := op.client.apiClient().DeletePermissionKeyWithResponse(ctx, siteId,
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return err
+	}
+	resp, err := apiClient.DeletePermissionKeyWithResponse(ctx, siteId,
 		v1.PermissionID(permissionId), v1.AccessKeyID(accessKeyId))
 	if err != nil {
 		return err

--- a/site_status.go
+++ b/site_status.go
@@ -38,7 +38,11 @@ func NewSiteStatusOp(client *Client) SiteStatusAPI {
 }
 
 func (op *siteStatusOp) Read(ctx context.Context, siteId string) (*v1.Status, error) {
-	resp, err := op.client.apiClient().GetStatusWithResponse(ctx, siteId)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.GetStatusWithResponse(ctx, siteId)
 	if err != nil {
 		return nil, err
 	}

--- a/sites.go
+++ b/sites.go
@@ -40,7 +40,11 @@ func NewSiteOp(client *Client) SiteAPI {
 }
 
 func (op *siteOp) List(ctx context.Context) ([]*v1.Cluster, error) {
-	resp, err := op.client.apiClient().GetClustersWithResponse(ctx)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.GetClustersWithResponse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +61,11 @@ func (op *siteOp) List(ctx context.Context) ([]*v1.Cluster, error) {
 }
 
 func (op *siteOp) Read(ctx context.Context, id string) (*v1.Cluster, error) {
-	resp, err := op.client.apiClient().GetClusterWithResponse(ctx, id)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.GetClusterWithResponse(ctx, id)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
sacloud/api-client-goを導入する。

これにより各種環境変数(SAKURACLOUD_xxx)やUsacloud互換のプロファイル機能が利用可能になる。
オプションでこれらを無効にすることも可能。

```go
// 特にオプションを指定しなかった場合は環境変数+プロファイルが利用される
apiClient := &objectstorage.Client{}
```

```go
// 環境変数+プロファイルからの読み込みを無効にする場合(別途APIキーの指定が必要)
apiClient := &objectstorage.Client{
	DisableProfile: true,
	DisableEnv:     true,

	Token:       "xxx",
	Secret: "xxx",
}
```