### PR TITLE
エラーハンドリングの改善

### DIFF
--- a/apis/v1/errors.go
+++ b/apis/v1/errors.go
@@ -20,60 +20,50 @@ import (
 	"strings"
 )
 
-// errorResponser APIレスポンスが返すエラー型が実装すべきインターフェース
-//
-// Note: 本来は各エラー型(ErrorNNN)でerrorインターフェースを実装させたかったが、
-//       各エラー型にはswagger.yamlでErrorというフィールドが定義されているため実装できない。
-//       このため別途errorを返すためのインターフェースとしてerrorResponserを用いている。
-type errorResponser interface {
-	// ActualError ErrorNNNが示すerrorを組み立てて返す
-	ActualError() error
-}
-
 var (
-	_ errorResponser = (*Error400)(nil)
-	_ errorResponser = (*Error401)(nil)
-	_ errorResponser = (*Error403)(nil)
-	_ errorResponser = (*Error404)(nil)
-	_ errorResponser = (*Error409)(nil)
-	_ errorResponser = (*ErrorDefault)(nil)
+	_ error = (*Error400)(nil)
+	_ error = (*Error401)(nil)
+	_ error = (*Error403)(nil)
+	_ error = (*Error404)(nil)
+	_ error = (*Error409)(nil)
+	_ error = (*ErrorDefault)(nil)
 )
 
 var commonErrorFormat = "status: %d, message: %s, trace: %s, inner_error: %s"
 
 // ActualError ErrorNNNが示すerrorを組み立てて返す
-func (e Error400) ActualError() error {
-	return fmt.Errorf(commonErrorFormat, http.StatusBadRequest, e.Error.Message, e.Error.TraceId, e.Error.Errors)
+func (e Error400) Error() string {
+	return fmt.Sprintf(commonErrorFormat, http.StatusBadRequest, e.Detail.Message, e.Detail.TraceId, e.Detail.Errors)
 }
 
 // ActualError ErrorNNNが示すerrorを組み立てて返す
-func (e Error401) ActualError() error {
-	return fmt.Errorf(commonErrorFormat, http.StatusUnauthorized, e.Error.Message, e.Error.TraceId, e.Error.Errors)
+func (e Error401) Error() string {
+	return fmt.Sprintf(commonErrorFormat, http.StatusUnauthorized, e.Detail.Message, e.Detail.TraceId, e.Detail.Errors)
 }
 
 // ActualError ErrorNNNが示すerrorを組み立てて返す
-func (e Error403) ActualError() error {
-	return fmt.Errorf(commonErrorFormat, http.StatusForbidden, e.Error.Message, e.Error.TraceId, e.Error.Errors)
+func (e Error403) Error() string {
+	return fmt.Sprintf(commonErrorFormat, http.StatusForbidden, e.Detail.Message, e.Detail.TraceId, e.Detail.Errors)
 }
 
 // ActualError ErrorNNNが示すerrorを組み立てて返す
-func (e Error404) ActualError() error {
-	return fmt.Errorf(commonErrorFormat, http.StatusNotFound, e.Error.Message, e.Error.TraceId, e.Error.Errors)
+func (e Error404) Error() string {
+	return fmt.Sprintf(commonErrorFormat, http.StatusNotFound, e.Detail.Message, e.Detail.TraceId, e.Detail.Errors)
 }
 
 // ActualError ErrorNNNが示すerrorを組み立てて返す
-func (e Error409) ActualError() error {
-	return fmt.Errorf(commonErrorFormat, http.StatusConflict, e.Error.Message, e.Error.TraceId, e.Error.Errors)
+func (e Error409) Error() string {
+	return fmt.Sprintf(commonErrorFormat, http.StatusConflict, e.Detail.Message, e.Detail.TraceId, e.Detail.Errors)
 }
 
 // ActualError ErrorNNNが示すerrorを組み立てて返す
-func (e ErrorDefault) ActualError() error {
-	status := e.Error.Code
+func (e ErrorDefault) Error() string {
+	status := e.Detail.Code
 	if status == 0 {
 		// この段階までに既知のステータスコード判定はされている。ここで不明な場合は500にしておく
 		status = http.StatusInternalServerError
 	}
-	return fmt.Errorf(commonErrorFormat, status, e.Error.Message, e.Error.TraceId, e.Error.Errors)
+	return fmt.Sprintf(commonErrorFormat, status, e.Detail.Message, e.Detail.TraceId, e.Detail.Errors)
 }
 
 // String Stringer実装

--- a/apis/v1/functions.go
+++ b/apis/v1/functions.go
@@ -35,8 +35,6 @@ func toError(v interface{}) error {
 	switch err := v.(type) {
 	case error:
 		return err
-	case errorResponser:
-		return err.ActualError()
 	default:
 		msg := fmt.Sprintf("invalid arg: %#+v", v)
 		panic(msg)

--- a/apis/v1/spec/swagger.yaml
+++ b/apis/v1/spec/swagger.yaml
@@ -1858,50 +1858,52 @@ components:
     Error400:
       type: object
       properties:
-        error:
+        detail:
           $ref: "#/components/schemas/ErrorDetail"
       required:
-        - error
+        - detail
     Error401:
       type: object
       properties:
-        error:
+        detail:
           $ref: "#/components/schemas/ErrorDetail"
       required:
-        - error
+        - detail
     Error403:
       type: object
       properties:
-        error:
+        detail:
           $ref: "#/components/schemas/ErrorDetail"
       required:
-        - error
+        - detail
     Error404:
       type: object
       properties:
-        error:
+        detail:
           $ref: "#/components/schemas/ErrorDetail"
       required:
-        - error
+        - detail
     Error409:
       type: object
       properties:
-        error:
+        detail:
           $ref: "#/components/schemas/ErrorDetail"
       required:
-        - error
+        - detail
     ErrorDefault:
       type: object
       properties:
-        error:
+        detail:
           $ref: "#/components/schemas/ErrorDetail"
       required:
-        - error
+        - detail
 
     # ErrorNNNから切り出し
     ErrorDetail:
       description: error
       type: object
+      x-oapi-codegen-extra-tags:
+        json: "error"
       properties:
         code:
           $ref: '#/components/schemas/ErrorCode'

--- a/apis/v1/zz_types_gen.go
+++ b/apis/v1/zz_types_gen.go
@@ -186,31 +186,31 @@ type Error struct {
 // Error400 defines model for Error400.
 type Error400 struct {
 	// error
-	Error ErrorDetail `json:"error"`
+	Detail ErrorDetail `json:"error"`
 }
 
 // Error401 defines model for Error401.
 type Error401 struct {
 	// error
-	Error ErrorDetail `json:"error"`
+	Detail ErrorDetail `json:"error"`
 }
 
 // Error403 defines model for Error403.
 type Error403 struct {
 	// error
-	Error ErrorDetail `json:"error"`
+	Detail ErrorDetail `json:"error"`
 }
 
 // Error404 defines model for Error404.
 type Error404 struct {
 	// error
-	Error ErrorDetail `json:"error"`
+	Detail ErrorDetail `json:"error"`
 }
 
 // Error409 defines model for Error409.
 type Error409 struct {
 	// error
-	Error ErrorDetail `json:"error"`
+	Detail ErrorDetail `json:"error"`
 }
 
 // エラーコード。
@@ -219,7 +219,7 @@ type ErrorCode int32
 // ErrorDefault defines model for ErrorDefault.
 type ErrorDefault struct {
 	// error
-	Error ErrorDetail `json:"error"`
+	Detail ErrorDetail `json:"error"`
 }
 
 // error

--- a/fake/server/server.go
+++ b/fake/server/server.go
@@ -59,7 +59,7 @@ func (s *Server) handleError(c *gin.Context, err error) {
 		switch engineErr.Type {
 		case fake.ErrorTypeInvalidRequest:
 			c.JSON(http.StatusBadRequest, &v1.Error400{
-				Error: v1.ErrorDetail{
+				Detail: v1.ErrorDetail{
 					Code:    http.StatusBadRequest,
 					Message: v1.ErrorMessage(engineErr.Error()),
 				},
@@ -67,7 +67,7 @@ func (s *Server) handleError(c *gin.Context, err error) {
 			return
 		case fake.ErrorTypeNotFound:
 			c.JSON(http.StatusNotFound, &v1.Error404{
-				Error: v1.ErrorDetail{
+				Detail: v1.ErrorDetail{
 					Code:    http.StatusNotFound,
 					Message: v1.ErrorMessage(engineErr.Error()),
 				},
@@ -75,7 +75,7 @@ func (s *Server) handleError(c *gin.Context, err error) {
 			return
 		case fake.ErrorTypeConflict:
 			c.JSON(http.StatusConflict, &v1.Error409{
-				Error: v1.ErrorDetail{
+				Detail: v1.ErrorDetail{
 					Code:    http.StatusConflict,
 					Message: v1.ErrorMessage(engineErr.Error()),
 				},


### PR DESCRIPTION
closes #32 

- エラーレスポンス後に再度レスポンスを書いてしまう問題を修正
- ErrorNNN型でerrorインターフェースを実装

ErrorNNN型はErrorというフィールドを持つためにerrorインターフェースを実装できなかったが、oapi-codegenのx-oapi-codegen-extra-tagsエクステンションを用いてフィールドの名前を変えつつJSONタグは維持することでこの問題を解消しerrorインターフェースを実装した。

これにより、クライアント側で以下のような判定が行えるようになる。

```go
	account, err := client.Read(ctx, req.SiteId)
	if err != nil {
		if _, ok := err.(*v1.Error404); ok {
			// 404エラー時の処理をここで実装
		}
		return nil, err
	}
```