### PR TITLE
サイトステータスAPIに404レスポンスを追加

### DIFF
--- a/apis/v1/spec/swagger.yaml
+++ b/apis/v1/spec/swagger.yaml
@@ -1361,6 +1361,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '404':
+          description: サイトが見つかりませんでした
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
         default:
           description: 不明なエラーです
           content:

--- a/fake/clusters.go
+++ b/fake/clusters.go
@@ -74,7 +74,6 @@ func (engine *Engine) copyCluster(source *v1.Cluster) (*v1.Cluster, error) {
 }
 
 func (engine *Engine) siteExist(siteName string) error {
-	// Note: API定義上は定義されていないがサイトがないケースでは404が返される
 	if cluster := engine.getClusterById(siteName); cluster == nil {
 		return newError(ErrorTypeNotFound, "cluster", "",
 			"指定のサイトは存在しません。site_name: %s", siteName)


### PR DESCRIPTION
サイトステータスAPIで存在しないサイトIDを指定した場合に404が返るケースをAPI定義に追加